### PR TITLE
Fix client components and syntax issues

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { ForgotPassword } from "@clerk/nextjs";
 
 export default function ForgotPasswordPage() {

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { ResetPassword } from "@clerk/nextjs";
 
 export default function ResetPasswordPage() {

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { SignIn } from "@clerk/nextjs";
 
 export default function SignInPage() {

--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TalentSignUpForm } from '@/components/TalentSignUpForm';

--- a/app/client/projects/details/[project_id]/page.tsx
+++ b/app/client/projects/details/[project_id]/page.tsx
@@ -27,11 +27,12 @@ export default function ClientProjectDetail() {
       if (data?.talent_id) {
       const tRes = await fetch('/api/db?table=talent_profiles');
       const tJson = await tRes.json();
-      if (tRes.ok) {
-      const talent = (tJson.data || []).find((p: any) => p.id ===   data.talent_id);
-      if (talent) setTalentProfile(talent);
-          }
+        if (tRes.ok) {
+          const talent = (tJson.data || []).find((p: any) => p.id === data.talent_id);
+          if (talent) setTalentProfile(talent);
+        }
       }
+    }
     };
 
     fetchProject();

--- a/app/client/projects/details/page.tsx
+++ b/app/client/projects/details/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/lib/useAuth';

--- a/app/talent/projects/details/page.tsx
+++ b/app/talent/projects/details/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/lib/useAuth';

--- a/app/talent/projects/page.tsx
+++ b/app/talent/projects/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState, useMemo, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';

--- a/app/talent/projects/project list/page.tsx
+++ b/app/talent/projects/project list/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';

--- a/app/talent/projects/workspace/page.tsx
+++ b/app/talent/projects/workspace/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 // ProjectWorkspace.tsx (Talent View)
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';

--- a/app/talent/sign-up/page.tsx
+++ b/app/talent/sign-up/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { SignUp } from "@clerk/nextjs";
 
 export default function TalentSignUpPage() {

--- a/components/BidFlow.tsx
+++ b/components/BidFlow.tsx
@@ -140,33 +140,4 @@ export default function BidFlow({ projectId, isAdmin = false }: { projectId: str
     </div>
   );
 }
-        </Button>
-      </div>
 
-      {filteredBids.length === 0 ? (
-        <p className="text-gray-500">No bids meet the current qualification level</p>
-      ) : (
-        filteredBids.map((bid) => (
-          <div key={bid.id} className="border p-4 rounded flex justify-between items-center">
-            <div>
-              <p className="font-medium">{bid.name}</p>
-              <ExperienceBadge badge={bid.badge} size="sm" showTooltip />
-              {badgeRank[bid.badge] < badgeRank[project.minimum_badge || 'Specialist'] && (
-                <p className="text-xs text-yellow-500 mt-1">Below project requirements</p>
-              )}
-            </div>
-            <div className="flex items-center gap-4">
-              <p className="text-sm text-gray-700">${bid.ratePerHour}/hr</p>
-              {isAdmin && (
-                <Button size="sm" onClick={() => handlePickWinner(bid.professional_id)}>
-                  Mark as Winner
-                </Button>
-              )}
-            </div>
-          </div>
-        ))
-      )}
-    </div>
-  )
-}
-      

--- a/components/SignInForm.tsx
+++ b/components/SignInForm.tsx
@@ -3,4 +3,5 @@ import { SignIn } from '@clerk/nextjs';
 
 export function SignInForm() {
   return <SignIn redirectUrl="/dashboard" />;
+}
 

--- a/components/admin/TrustScoreList.tsx
+++ b/components/admin/TrustScoreList.tsx
@@ -118,7 +118,7 @@ export default function TrustScoreList() {
     if (score >= 40) return <Badge className="bg-yellow-100 text-yellow-800 border-yellow-200">Fair</Badge>;
     return <Badge className="bg-red-100 text-red-800 border-red-200">Poor</Badge>;
   };
-}
+
   const viewTalentDetails = (talentId: string) => {
     navigate(`/admin/talent/${talentId}`);
   };
@@ -304,3 +304,4 @@ export default function TrustScoreList() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- mark several pages as client components
- fix syntax errors in `BidFlow` and `SignInForm`
- remove stray brace in `TrustScoreList`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit` on selected files *(fails: Cannot use JSX unless the '--jsx' flag is provided)*

------
https://chatgpt.com/codex/tasks/task_e_6864071ff09483279c773e3c786d64c8