### PR TITLE
Fix Clerk usage and type safety

### DIFF
--- a/api/admin/projects/route.ts
+++ b/api/admin/projects/route.ts
@@ -5,9 +5,10 @@ import { auth } from '@clerk/nextjs';
 
 export async function GET(_req: NextRequest) {
   const { userId, sessionClaims } = auth();
-  
+  const role = (sessionClaims as { metadata?: { role?: string } })?.metadata?.role;
+
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { ForgotPassword } from "@clerk/nextjs";
 
 export default function ForgotPasswordPage() {
   return (

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { ResetPassword } from "@clerk/nextjs";
 
 export default function ResetPasswordPage() {
   return (

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,8 @@
 // middleware.ts
-import { clerkMiddleware } from '@clerk/nextjs/server';
+import { authMiddleware } from '@clerk/nextjs';
 import { NextResponse } from "next/server";
 
-export default clerkMiddleware((auth, req) => {
+export default authMiddleware((auth, req) => {
   const { userId, sessionClaims } = auth();
   const role = sessionClaims?.metadata?.role as string | undefined;
 


### PR DESCRIPTION
## Summary
- remove invalid Clerk imports from reset/forgot password pages
- switch to `authMiddleware` in middleware
- fix admin projects API type check

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644ce16b5c8327bbebd1bc4205587e