### PR TITLE
Fix clerk webhook type assertion

### DIFF
--- a/api/clerk/webhook/route.ts
+++ b/api/clerk/webhook/route.ts
@@ -3,12 +3,17 @@ import { Webhook } from 'svix';
 import { db } from '@/lib/db';
 import { users, talentProfiles, clientProfiles } from '@/lib/schema';
 
+interface ClerkWebhookEvent {
+  type: string;
+  data: any;
+}
+
 export async function POST(req: NextRequest) {
   const payload = await req.text();
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 
   try {
-    const evt = wh.verify(payload, req.headers as any);
+    const evt = wh.verify(payload, req.headers as any) as ClerkWebhookEvent;
     console.log('Clerk webhook event', evt.type);
 
     if (evt.type === 'user.created') {


### PR DESCRIPTION
## Summary
- define `ClerkWebhookEvent` in Clerk webhook route
- cast verified event so `evt.type` can be accessed safely

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865481a80a88327a130c97571f28b98