### PR TITLE
Fix sessionClaims typing in client route

### DIFF
--- a/api/clients/[id].ts
+++ b/api/clients/[id].ts
@@ -2,8 +2,15 @@ import { getClientById } from '@/lib/apiHandlers/clients';
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
 
+type SessionClaimsWithRole = {
+  metadata?: {
+    role?: string;
+  };
+};
+
 export async function GET(_: Request, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated
   if (!userId) {
@@ -11,7 +18,7 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   }
   
   // Check if user is admin or the client themselves
-  const isAdmin = sessionClaims?.metadata?.role === 'admin';
+  const isAdmin = role === 'admin';
   const isOwnProfile = userId === params.id;
   
   if (!isAdmin && !isOwnProfile) {


### PR DESCRIPTION
## Summary
- ensure sessionClaims has metadata.role type in `/api/clients/[id].ts`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654ad663d88327acdda61195384a88