### PR TITLE
Fix metadata.role typing

### DIFF
--- a/api/clients/[id]/projects.ts
+++ b/api/clients/[id]/projects.ts
@@ -1,9 +1,11 @@
 import { getClientProjects } from '@/lib/apiHandlers/clients';
 import { NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(_: Request, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated
   if (!userId) {
@@ -11,7 +13,7 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
   }
   
   // Check if user is admin or the client themselves
-  const isAdmin = sessionClaims?.metadata?.role === 'admin';
+  const isAdmin = role === 'admin';
   const isOwnProfile = userId === params.id;
   
   if (!isAdmin && !isOwnProfile) {

--- a/api/clients/[id]/trust-score/route.ts
+++ b/api/clients/[id]/trust-score/route.ts
@@ -3,15 +3,17 @@ import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function POST(
   _req: Request,
   { params }: { params: { id: string } }
 ) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/api/clients/route.ts
+++ b/api/clients/route.ts
@@ -3,12 +3,14 @@ import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET() {
   const { userId, sessionClaims } = auth();
-  
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
+
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/api/db/route.ts
+++ b/api/db/route.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { users, projects, talentProfiles } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(request: NextRequest) {
   const { userId } = auth();
@@ -143,9 +144,10 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/api/talent/[id]/flag.ts
+++ b/api/talent/[id]/flag.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { flagTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/api/talent/[id]/qualify.ts
+++ b/api/talent/[id]/qualify.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { qualifyTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/api/talent/[id]/trust-score.ts
+++ b/api/talent/[id]/trust-score.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from 'next/server';
 import { updateTalentTrustScore } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function POST(_: Request, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role
-  if (!userId || sessionClaims?.metadata?.role !== 'admin') {
+  if (!userId || role !== 'admin') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,7 @@
+export interface MetadataWithRole {
+  role?: string;
+}
+
+export interface SessionClaimsWithRole {
+  metadata?: MetadataWithRole;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,12 @@
 // middleware.ts
 import { authMiddleware } from '@clerk/nextjs';
 import { NextResponse } from "next/server";
+import type { SessionClaimsWithRole } from '@/lib/types';
 
 export default authMiddleware((auth, req) => {
   const { userId, sessionClaims } = auth();
-  const role = sessionClaims?.metadata?.role as string | undefined;
+  const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role as
+    string | undefined;
 
   const pathname = req.nextUrl.pathname;
 


### PR DESCRIPTION
## Summary
- add a shared `SessionClaimsWithRole` interface
- use that type when reading `metadata.role`

## Testing
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6865509f7f988327a1f21502acf72d90