### PR TITLE
Fix fetch in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/scripts/processBrief.js
+++ b/scripts/processBrief.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import pdfParse from 'pdf-parse';
 
 async function extractTextFromPDF(url) {


### PR DESCRIPTION
## Summary
- rely on the built-in `fetch` instead of `node-fetch`
- specify Node 18+ in `package.json`

## Testing
- `yarn install --immutable` *(fails: RequestError 403)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686558c7382c8327a08770e22a883310