### PR TITLE
Fix tsconfig include

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,5 +8,5 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src", "scripts"]
+  "include": ["app", "scripts"]
 }


### PR DESCRIPTION
## Summary
- update `tsconfig.node.json` to point to `app` instead of `src`

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68655a30030c83279f76db08bbaad5e0