### PR TITLE
Fix Clerk imports for password pages

### DIFF
--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { ForgotPassword } from '@clerk/nextjs'; // or correct this import path
-// 🚫 Removed: import ForgotPasswordPage from './ForgotPasswordPage';
+import { ForgotPassword } from '@clerk/nextjs';
 
 export default function ForgotPasswordPage() {
   return (

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ResetPassword } from '@clerk/nextjs';
 
 export default function ResetPasswordPage() {
   return (


### PR DESCRIPTION
## Summary
- correct Clerk imports for auth password pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68658a3ec50c83278b560da726448dd3