### PR TITLE
Fix TalentSignUpForm props type

### DIFF
--- a/components/TalentSignUpForm.tsx
+++ b/components/TalentSignUpForm.tsx
@@ -1,7 +1,14 @@
 'use client';
 import { SignUp } from '@clerk/nextjs';
 
-export function TalentSignUpForm() {
+interface TalentSignUpFormProps {
+  loading: boolean;
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function TalentSignUpForm({ loading, setLoading }: TalentSignUpFormProps) {
+  void loading;
+  void setLoading;
   return (
         <SignUp signInUrl="/sign-in" redirectUrl="/talent/dashboard" />
   );


### PR DESCRIPTION
## Summary
- define props for TalentSignUpForm
- accept loading and setLoading props without lint errors

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68659e7194b08327b3b72776308674fc