### PR TITLE
Add success variant for Badge component

### DIFF
--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -14,6 +14,8 @@ const badgeVariants = cva(
           'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        success:
+          'border-transparent bg-green-500 text-primary-foreground shadow hover:bg-green-600',
         outline: 'text-foreground',
       },
     },


### PR DESCRIPTION
## Summary
- extend `Badge` component with a `success` variant so admin and project pages can use it

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a89baad48327b8aecd583f03bf7f