### PR TITLE
Fix talent import name

### DIFF
--- a/app/api/talent/[id].ts
+++ b/app/api/talent/[id].ts
@@ -1,18 +1,18 @@
 import { db } from '@/lib/db';
 import { eq } from 'drizzle-orm';
-import { talent_profiles } from '@/lib/schema';
+import { talentProfiles } from '@/lib/schema';
 
 export async function getTalentById(id: string) {
-  const result = await db.select().from(talent_profiles).where(eq(talent_profiles.id, id)).limit(1);
+  const result = await db.select().from(talentProfiles).where(eq(talentProfiles.id, id)).limit(1);
   return result[0] || null;
 }
 
 export async function updateTalentTrustScore(id: string) {
   // Example logic: increment trust score
   const result = await db
-    .update(talent_profiles)
+    .update(talentProfiles)
     .set({ trust_score: Math.floor(Math.random() * 100), trust_score_updated_at: new Date().toISOString() })
-    .where(eq(talent_profiles.id, id))
+    .where(eq(talentProfiles.id, id))
     .returning();
   return result[0];
 }
@@ -24,13 +24,13 @@ export async function flagTalent(id: string, reason: string) {
 
 export async function qualifyTalent(id: string, qualified: boolean) {
   const result = await db
-    .update(talent_profiles)
+    .update(talentProfiles)
     .set({
       is_qualified: qualified,
       qualification_reason: 'manual',
       qualification_history: JSON.stringify([{ reason: 'manual', timestamp: new Date().toISOString() }])
     })
-    .where(eq(talent_profiles.id, id))
+    .where(eq(talentProfiles.id, id))
     .returning();
   return result[0];
 }


### PR DESCRIPTION
## Summary
- use `talentProfiles` import name in API endpoint

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@neondatabase/serverless' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6865af06d4fc8327846fb7119756f97b