### PR TITLE
Fix runtime constant and date for trust score update

### DIFF
--- a/app/api/talent/[id].ts
+++ b/app/api/talent/[id].ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { db } from '@/lib/db';
 import { eq } from 'drizzle-orm';
 import { talentProfiles } from '@/lib/schema';
@@ -11,7 +13,7 @@ export async function updateTalentTrustScore(id: string) {
   // Example logic: increment trust score
   const result = await db
     .update(talentProfiles)
-    .set({ trustScore: Math.floor(Math.random() * 100), trustScoreUpdatedAt: new Date().toISOString() })
+    .set({ trustScore: Math.floor(Math.random() * 100), trustScoreUpdatedAt: new Date() })
     .where(eq(talentProfiles.id, id))
     .returning();
   return result[0];


### PR DESCRIPTION
## Summary
- set `runtime` to `nodejs` in talent API endpoint
- update trust score timestamp to use `new Date()`

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5f62af883278eb922dc5f184e60