### PR TITLE
Fix camelCase fields in talent update

### DIFF
--- a/app/api/talent/[id].ts
+++ b/app/api/talent/[id].ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { db } from '@/lib/db';
 import { eq } from 'drizzle-orm';
 import { talentProfiles } from '@/lib/schema';
@@ -11,7 +13,7 @@ export async function updateTalentTrustScore(id: string) {
   // Example logic: increment trust score
   const result = await db
     .update(talentProfiles)
-    .set({ trustScore: Math.floor(Math.random() * 100), trustScoreUpdatedAt: new Date().toISOString() })
+    .set({ trustScore: Math.floor(Math.random() * 100), trustScoreUpdatedAt: new Date() })
     .where(eq(talentProfiles.id, id))
     .returning();
   return result[0];
@@ -26,9 +28,9 @@ export async function qualifyTalent(id: string, qualified: boolean) {
   const result = await db
     .update(talentProfiles)
     .set({
-      is_qualified: qualified,
-      qualification_reason: 'manual',
-      qualification_history: JSON.stringify([{ reason: 'manual', timestamp: new Date().toISOString() }])
+      isQualified: qualified,
+      qualificationReason: 'manual',
+      qualificationHistory: JSON.stringify([{ reason: 'manual', timestamp: new Date().toISOString() }])
     })
     .where(eq(talentProfiles.id, id))
     .returning();


### PR DESCRIPTION
## Summary
- update trust score endpoint already set
- use camelCase field names in `qualifyTalent` update

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5f62af883278eb922dc5f184e60