### PR TITLE
Fix camelCase schema fields

### DIFF
--- a/components/AdminLineChart.tsx
+++ b/components/AdminLineChart.tsx
@@ -89,18 +89,18 @@ export default function AdminLineChart({ selectedMetrics }: AdminLineChartProps)
         }
 
         projects?.forEach(p => {
-          const m = new Date(p.created_at).toLocaleString('default', { month: 'short' });
+          const m = new Date(p.createdAt).toLocaleString('default', { month: 'short' });
           const bucket = months[m];
           if (!bucket) return;
           bucket.totalProjects += 1;
-          bucket.estRevenue += p.project_budget || 0;
+          bucket.estRevenue += p.projectBudget || 0;
           if (p.flagged) bucket.flaggedProjects += 1;
         });
 
         const talentMonths: Record<string, Set<string>> = {};
         talents?.forEach(t => {
           if (!t.isQualified) return;
-          const m = new Date(t.created_at).toLocaleString('default', { month: 'short' });
+          const m = new Date(t.createdAt).toLocaleString('default', { month: 'short' });
           if (!talentMonths[m]) talentMonths[m] = new Set();
           talentMonths[m].add(t.id);
         });
@@ -110,7 +110,7 @@ export default function AdminLineChart({ selectedMetrics }: AdminLineChartProps)
 
         reviews?.forEach(r => {
           if (r.rating < 3) {
-            const m = new Date(r.created_at).toLocaleString('default', { month: 'short' });
+            const m = new Date(r.createdAt).toLocaleString('default', { month: 'short' });
             if (months[m]) months[m].negativeReviews += 1;
           }
         });

--- a/components/AdminProjectList.tsx
+++ b/components/AdminProjectList.tsx
@@ -22,8 +22,8 @@ interface AdminProject {
   description: string;
   status: string;
   deadline: string;
-  project_budget?: number;
-  project_bids?: Array<{ count: number }>;
+  projectBudget?: number;
+  projectBids?: Array<{ count: number }>;
 }
 
 export default function AdminProjectList() {
@@ -66,17 +66,17 @@ export default function AdminProjectList() {
       }
 
       if (bidFilter === "0") {
-        filteredData = filteredData.filter(p => !p.project_bids[0]?.count || p.project_bids[0].count === 0);
+        filteredData = filteredData.filter(p => !p.projectBids[0]?.count || p.projectBids[0].count === 0);
       } else if (bidFilter === "1+") {
-        filteredData = filteredData.filter(p => p.project_bids[0]?.count > 0);
+        filteredData = filteredData.filter(p => p.projectBids[0]?.count > 0);
       }
 
       if (revenueFilter === "low") {
-        filteredData = filteredData.filter(p => (p.project_budget || 0) < 2000);
+        filteredData = filteredData.filter(p => (p.projectBudget || 0) < 2000);
       } else if (revenueFilter === "med") {
-        filteredData = filteredData.filter(p => (p.project_budget || 0) >= 2000 && (p.project_budget || 0) <= 4000);
+        filteredData = filteredData.filter(p => (p.projectBudget || 0) >= 2000 && (p.projectBudget || 0) <= 4000);
       } else if (revenueFilter === "high") {
-        filteredData = filteredData.filter(p => (p.project_budget || 0) > 4000);
+        filteredData = filteredData.filter(p => (p.projectBudget || 0) > 4000);
       }
 
       if (searchQuery) {
@@ -186,7 +186,7 @@ export default function AdminProjectList() {
               </TableRow>
             ) : (
               projects.map((project: AdminProject) => {
-                const budget = project.project_budget || 0;
+                const budget = project.projectBudget || 0;
                 const platformFee = budget * 0.1;
 
                 return (
@@ -195,7 +195,7 @@ export default function AdminProjectList() {
                     <TableCell>
                       <Badge variant="secondary">{project.status}</Badge>
                     </TableCell>
-                    <TableCell>{project.project_bids?.[0]?.count || 0}</TableCell>
+                    <TableCell>{project.projectBids?.[0]?.count || 0}</TableCell>
                     <TableCell>{new Date(project.deadline).toLocaleDateString()}</TableCell>
                     <TableCell className="max-w-[250px] truncate">{project.description}</TableCell>
                     <TableCell className="text-xs font-mono">{project.id}</TableCell>

--- a/components/AdminTalentList.tsx
+++ b/components/AdminTalentList.tsx
@@ -36,14 +36,14 @@ const ITEMS_PER_PAGE = 10;
 
 interface TalentProfile {
   id: string;
-  full_name: string;
+  fullName: string;
   email: string;
   expertise: string;
-  trust_score: number | null;
+  trustScore: number | null;
   isQualified: boolean;
   joinMethod?: string;
-  qualification_reason?: string;
-  qualification_history?: string[];
+  qualificationReason?: string;
+  qualificationHistory?: string[];
 }
 
 export default function AdminTalentList() {
@@ -80,7 +80,7 @@ export default function AdminTalentList() {
 
       if (debouncedSearch) {
         data = data.filter((t: any) =>
-          t.full_name.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
+          t.fullName.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
           t.email.toLowerCase().includes(debouncedSearch.toLowerCase()) ||
           t.expertise.toLowerCase().includes(debouncedSearch.toLowerCase())
         );
@@ -92,7 +92,7 @@ export default function AdminTalentList() {
 
       if (trustScoreFilter !== 'all') {
         data = data.filter((t: any) => {
-          const s = t.trust_score ?? 0;
+          const s = t.trustScore ?? 0;
           if (trustScoreFilter === 'high') return s >= 80;
           if (trustScoreFilter === 'medium') return s >= 60 && s < 80;
           if (trustScoreFilter === 'low') return s >= 40 && s < 60;
@@ -319,7 +319,7 @@ export default function AdminTalentList() {
                       onChange={() => toggleSelect(talent.id)}
                     />
                   </TableCell>
-                  <TableCell className="font-medium">{talent.full_name}</TableCell>
+                  <TableCell className="font-medium">{talent.fullName}</TableCell>
                   <TableCell>{talent.email}</TableCell>
                   <TableCell>{talent.expertise}</TableCell>
                   <TableCell>{talent.location || 'N/A'}</TableCell>
@@ -330,18 +330,18 @@ export default function AdminTalentList() {
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
-                      {talent.trust_score !== null && talent.trust_score !== undefined ? (
+                      {talent.trustScore !== null && talent.trustScore !== undefined ? (
                         <>
                           <span className={`font-bold ${
-                            talent.trust_score >= 80 ? 'text-green-600' : 
-                            talent.trust_score >= 60 ? 'text-blue-600' : 
-                            talent.trust_score >= 40 ? 'text-yellow-600' : 
+                            talent.trustScore >= 80 ? 'text-green-600' :
+                            talent.trustScore >= 60 ? 'text-blue-600' :
+                            talent.trustScore >= 40 ? 'text-yellow-600' :
                             'text-red-600'
                           }`}>
-                            {talent.trust_score.toFixed(1)}
+                            {talent.trustScore.toFixed(1)}
                           </span>
-                          {getTrustScoreBadge(talent.trust_score)}
-                          {talent.trust_score < 40 && (
+                          {getTrustScoreBadge(talent.trustScore)}
+                          {talent.trustScore < 40 && (
                             <AlertTriangle className="h-4 w-4 text-red-500" title="Performance Improvement Plan Required" />
                           )}
                         </>
@@ -358,9 +358,9 @@ export default function AdminTalentList() {
                         <RefreshCw className={`h-4 w-4 ${updatingTrustScore === talent.id ? 'animate-spin' : ''}`} />
                       </Button>
                     </div>
-                    {talent.trust_score_updated_at && (
+                    {talent.trustScoreUpdatedAt && (
                       <p className="text-xs text-gray-500 mt-1">
-                        Updated: {new Date(talent.trust_score_updated_at).toLocaleDateString()}
+                        Updated: {new Date(talent.trustScoreUpdatedAt).toLocaleDateString()}
                       </p>
                     )}
                   </TableCell>

--- a/components/BidFlow.tsx
+++ b/components/BidFlow.tsx
@@ -14,7 +14,7 @@ const badgeRank: Record<string, number> = {
 interface Project {
   id: string;
   title: string;
-  minimum_badge?: string;
+  minimumBadge?: string;
 }
 
 interface Bid {
@@ -22,7 +22,7 @@ interface Bid {
   ratePerHour: number;
   name: string;
   badge: string;
-  professional_id: string;
+  professionalId: string;
 }
 
 export default function BidFlow({ projectId, isAdmin = false }: { projectId: string; isAdmin?: boolean }) {
@@ -44,15 +44,15 @@ export default function BidFlow({ projectId, isAdmin = false }: { projectId: str
         const bidsJson = await bidsRes.json();
 
         setProject(projectData);
-        const bidList = (bidsJson.data || []).filter((b: any) => b.project_id === projectId);
+        const bidList = (bidsJson.data || []).filter((b: any) => b.projectId === projectId);
 
         setBids(
           bidList.map((bid: any) => ({
             id: bid.id,
-            ratePerHour: bid.rate_per_hour,
-            name: bid.professional_id,
+            ratePerHour: bid.ratePerHour,
+            name: bid.professionalId,
             badge: '',
-            professional_id: bid.professional_id,
+            professionalId: bid.professionalId,
           }))
         );
       } catch (error) {
@@ -77,8 +77,8 @@ export default function BidFlow({ projectId, isAdmin = false }: { projectId: str
           table: 'projects',
           id: project?.id,
           data: {
-            winning_bid_id: professionalId,
-            talent_id: professionalId,
+            winningBidId: professionalId,
+            talentId: professionalId,
             status: 'in_progress',
           },
         }),
@@ -106,7 +106,7 @@ export default function BidFlow({ projectId, isAdmin = false }: { projectId: str
   const filteredBids = showAllBids
     ? bids
     : bids.filter(
-        (bid) => badgeRank[bid.badge] >= badgeRank[project.minimum_badge || 'Specialist']
+        (bid) => badgeRank[bid.badge] >= badgeRank[project.minimumBadge || 'Specialist']
       );
 
   return (
@@ -131,7 +131,7 @@ export default function BidFlow({ projectId, isAdmin = false }: { projectId: str
             <div className="font-bold text-lg">${bid.ratePerHour}/hr</div>
           </div>
           {isAdmin && (
-            <Button onClick={() => handlePickWinner(bid.professional_id)}>
+            <Button onClick={() => handlePickWinner(bid.professionalId)}>
               Pick Winner
             </Button>
           )}

--- a/components/CompletedProjectsList.tsx
+++ b/components/CompletedProjectsList.tsx
@@ -10,7 +10,7 @@ interface CompletedProject {
   title: string;
   description: string;
   expertiseLevel: string;
-  completed_at: string; // ISO date
+  completedAt: string; // ISO date
   visibility: 'public' | 'private';
 }
 
@@ -24,7 +24,7 @@ export function CompletedProjectsList({ userId }: { userId: string }) {
       const json = await res.json();
       if (res.ok) {
         const all = json.data || [];
-        setProjects(all.filter((p: any) => p.status === 'completed' && p.talent_id === userId));
+        setProjects(all.filter((p: any) => p.status === 'completed' && p.talentId === userId));
       }
     }
 
@@ -53,7 +53,7 @@ export function CompletedProjectsList({ userId }: { userId: string }) {
                 <h3 className="text-lg font-semibold">{project.title}</h3>
                 <p className="text-sm text-muted-foreground">{project.description}</p>
                 <p className="text-xs text-gray-500">
-                  Completed on {format(new Date(project.completed_at), 'PPP')}
+                  Completed on {format(new Date(project.completedAt), 'PPP')}
                 </p>
                 {project.visibility === 'private' && (
                   <span className="text-xs text-orange-500">🔒 Private</span>

--- a/components/NotificationBell.tsx
+++ b/components/NotificationBell.tsx
@@ -13,35 +13,35 @@ const mockNotifications = [
     title: 'New Project Available',
     message: 'A new SEO project matching your skills is available',
     type: 'project_update',
-    is_read: false,
-    created_at: new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30 minutes ago
-    metadata: { project_id: '123' }
+    isRead: false,
+    createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(), // 30 minutes ago
+    metadata: { projectId: '123' }
   },
   {
     id: '2',
     title: 'Bid Accepted',
     message: 'Your bid for "Content Strategy" was accepted',
     type: 'bid_update',
-    is_read: true,
-    created_at: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2 hours ago
-    metadata: { project_id: '456' }
+    isRead: true,
+    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(), // 2 hours ago
+    metadata: { projectId: '456' }
   }
 ];
 
 export default function NotificationBell() {
   const [notifications, setNotifications] = useState(mockNotifications);
-  const [unreadCount, setUnreadCount] = useState(notifications.filter(n => !n.is_read).length);
+  const [unreadCount, setUnreadCount] = useState(notifications.filter(n => !n.isRead).length);
 
   const markAsRead = (id: string) => {
     setNotifications(prev =>
-      prev.map(n => n.id === id ? { ...n, is_read: true } : n)
+      prev.map(n => n.id === id ? { ...n, isRead: true } : n)
     );
     setUnreadCount(prev => Math.max(0, prev - 1));
   };
 
   const markAllAsRead = () => {
     setNotifications(prev =>
-      prev.map(n => ({ ...n, is_read: true }))
+      prev.map(n => ({ ...n, isRead: true }))
     );
     setUnreadCount(0);
   };
@@ -88,14 +88,14 @@ export default function NotificationBell() {
                 <div
                   key={notification.id}
                   className={`p-4 transition-colors cursor-pointer hover:bg-gray-50 ${
-                    !notification.is_read ? 'bg-blue-50' : ''
+                    !notification.isRead ? 'bg-blue-50' : ''
                   }`}
-                  onClick={() => !notification.is_read && markAsRead(notification.id)}
+                  onClick={() => !notification.isRead && markAsRead(notification.id)}
                 >
                   <div className="flex justify-between items-start mb-1">
                     <h5 className="font-medium text-sm">{notification.title}</h5>
                     <span className="text-xs text-gray-500">
-                      {formatDistanceToNow(new Date(notification.created_at), { addSuffix: true })}
+                      {formatDistanceToNow(new Date(notification.createdAt), { addSuffix: true })}
                     </span>
                   </div>
                   <p className="text-sm text-gray-600">{notification.message}</p>

--- a/components/RevenuePanel.tsx
+++ b/components/RevenuePanel.tsx
@@ -77,8 +77,8 @@ export default function RevenuePanel() {
     const matchesSearch = project.title.toLowerCase().includes(searchQuery.toLowerCase());
     const matchesStatus = statusFilter === "all" || project.status === statusFilter;
     const matchesBids = bidFilter === "all" ||
-      (bidFilter === "0" && (project.project_bids?.length || 0) === 0) ||
-      (bidFilter === "1+" && (project.project_bids?.length || 0) > 0);
+      (bidFilter === "0" && (project.projectBids?.length || 0) === 0) ||
+      (bidFilter === "1+" && (project.projectBids?.length || 0) > 0);
     const budget = project.metadata?.marketing?.budget || 0;
     const matchesRevenue = revenueFilter === "all" ||
       (revenueFilter === "low" && budget < 2000) ||
@@ -124,7 +124,7 @@ export default function RevenuePanel() {
                 {filteredProjects.map((project) => (
                   <TableRow key={project.id}>
                     <TableCell className="font-medium">{project.title}</TableCell>
-                    <TableCell>{project.category_id}</TableCell>
+                    <TableCell>{project.categoryId}</TableCell>
                     <TableCell>
                       <Badge variant={project.status === 'completed' ? 'default' : 'secondary'}>
                         {project.status}
@@ -168,16 +168,16 @@ export default function RevenuePanel() {
               <TableBody>
                 {filteredEscrow.map((e) => (
                   <TableRow key={e.id}>
-                    <TableCell className="font-medium">{getProjectTitle(e.project_id)}</TableCell>
+                    <TableCell className="font-medium">{getProjectTitle(e.projectId)}</TableCell>
                     <TableCell>
                       <Badge variant={e.status === 'approved' ? 'default' : e.status === 'requested' ? 'secondary' : 'outline'}>
                         {e.status}
                       </Badge>
                     </TableCell>
-                    <TableCell>{new Date(e.created_at).toLocaleDateString()}</TableCell>
-                    <TableCell>{e.released_at ? new Date(e.released_at).toLocaleDateString() : '—'}</TableCell>
+                    <TableCell>{new Date(e.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell>{e.releasedAt ? new Date(e.releasedAt).toLocaleDateString() : '—'}</TableCell>
                     <TableCell>
-                      <Button size="sm" variant="outline" onClick={() => router.push(`/admin/projects/${e.project_id}`)}>
+                      <Button size="sm" variant="outline" onClick={() => router.push(`/admin/projects/${e.projectId}`)}>
                         Manage
                       </Button>
                     </TableCell>

--- a/components/ReviewForm.tsx
+++ b/components/ReviewForm.tsx
@@ -37,10 +37,10 @@ export default function ReviewForm({ projectId, onReviewSubmitted }: ReviewFormP
         body: JSON.stringify({
           table: 'project_reviews',
           data: {
-            project_id: projectId,
+            projectId,
             rating,
             comment,
-            add_to_portfolio: addToPortfolio
+            addToPortfolio
           }
         })
       });

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,12 +3,17 @@ import * as dotenv from 'dotenv';
 
 dotenv.config();
 
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error('DATABASE_URL is not defined');
+}
+
 export default {
   schema: './lib/schema.ts',
   out: './drizzle',
   driver: 'pg',
   dbCredentials: {
-    connectionString: process.env.DATABASE_URL as string,
+    connectionString,
   },
   verbose: true,
   strict: true,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/neon-http';
 import * as schema from './schema';
 
 // Get the database connection string from environment variables
-const connectionString: string = process.env.DATABASE_URL as string;
+const connectionString = process.env.DATABASE_URL;
 
 // Check if the connection string is defined
 if (!connectionString) {


### PR DESCRIPTION
## Summary
- use camelCase names in admin project list, admin talent list, bid flow, revenue panel and more
- guard DATABASE_URL usage and drizzle config
- keep internal enums in sync with schema literals

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@clerk/nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_6866b8caf8f88327a32fb14e5cfb8cdc