### PR TITLE
Fix Clerk SignUp and middleware typing

### DIFF
--- a/app/talent/sign-up/page.tsx
+++ b/app/talent/sign-up/page.tsx
@@ -30,10 +30,10 @@ export default function TalentSignUpPage() {
           }}
           signInUrl="/sign-in"
           redirectUrl="/talent/dashboard"
-          initialValues={{
-            role: "talent"
+          unsafeMetadata={{
+            role: "talent",
           }}
-        />
+          />
       </div>
     </main>
   );

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,10 +1,14 @@
 // middleware.ts
-import { authMiddleware } from '@clerk/nextjs';
-import { NextResponse, NextRequest } from "next/server";
+import { withClerkMiddleware, getAuth } from '@clerk/nextjs/server';
+import { NextResponse, type NextRequest } from "next/server";
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export default authMiddleware((auth, req: NextRequest) => {
-  const { userId, sessionClaims } = auth();
+export default withClerkMiddleware((req: NextRequest) => {
+  const { userId, sessionClaims } = getAuth(req);
+
+  if (!userId) {
+    return NextResponse.redirect(new URL('/sign-in', req.url));
+  }
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role as
     string | undefined;
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^4.31.8",
+    "@clerk/types": "^3.65.5",
     "@hookform/resolvers": "^3.3.4",
     "@neondatabase/serverless": "^0.9.0",
     "@netlify/plugin-nextjs": "^5.8.0",


### PR DESCRIPTION
## Summary
- handle role metadata with `unsafeMetadata` on talent sign up
- use `withClerkMiddleware` and `getAuth` for role-based middleware
- add `@clerk/types` dependency

## Testing
- `yarn lint` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6866bd4ad680832799440484da9594c8