### PR TITLE
Add dev setup script and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ npm install
 yarn install
 ```
 
-3. Set up environment variables:
+3. Install dev dependencies for linting and testing:
+```bash
+npm run setup:dev
+```
+
+
+4. Set up environment variables:
    - Copy `.env.example` to `.env`
    - Connect to Supabase using the "Connect to Supabase" button in the top right
    - Add your `SUPABASE_SERVICE_ROLE_KEY` from the Supabase dashboard
 
-4. Set up mock data (optional):
+5. Set up mock data (optional):
 
 ```bash
 npm run setup-mock-data
@@ -34,7 +40,7 @@ npm run setup-mock-data
 yarn setup-mock-data
 ```
 
-5. Start the development server:
+6. Start the development server:
 
 ```bash
 npm run dev
@@ -94,6 +100,11 @@ All mock users have the password: `password123`
 - `/public` - Static assets
 - `/styles` - Global styles and Tailwind configuration
 - `/scripts` - Setup and utility scripts
+
+## Linting and Tests
+
+Run `npm run lint` to check code style and `npm test` to run the Node.js test suite. Ensure dev dependencies are installed using `npm run setup:dev` before running these commands.
+
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "lint": "eslint .",
+  "lint": "eslint .",
+  "test": "node --test",
     "start": "next start",
     "db:push": "node --import dotenv/config node_modules/.bin/drizzle-kit push:pg",
     "db:generate": "node --import dotenv/config node_modules/.bin/drizzle-kit generate:pg",
@@ -17,7 +18,8 @@
     "seed-auth": "node --import dotenv/config scripts/seed-auth-users.js",
     "backfill-missing-ids": "node --import dotenv/config scripts/backfillMissingProjectIds.js",
     "recalculate-trust-scores": "node --import dotenv/config scripts/recalculateTrustScores.js",
-    "process-brief": "node scripts/processBrief.js"
+    "process-brief": "node scripts/processBrief.js",
+    "setup:dev": "./scripts/install-dev-deps.sh"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.31.8",
@@ -87,8 +89,13 @@
     "autoprefixer": "^10.4.17",
     "dotenv": "^16.4.1",
     "drizzle-kit": "^0.21.2",
-    "eslint": "^8.56.0",
-    "eslint-config-next": "14.1.0",
+  "eslint": "^8.56.0",
+  "@eslint/js": "^9.1.0",
+  "globals": "^15.2.0",
+  "eslint-plugin-react-hooks": "^4.6.0",
+  "eslint-plugin-react-refresh": "^0.4.1",
+  "typescript-eslint": "^7.6.0",
+  "eslint-config-next": "14.1.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",

--- a/scripts/install-dev-deps.sh
+++ b/scripts/install-dev-deps.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Install dev dependencies required for linting and testing
+set -e
+
+declare -a deps=(
+  "@eslint/js"
+  "globals"
+  "eslint-plugin-react-hooks"
+  "eslint-plugin-react-refresh"
+  "typescript-eslint"
+)
+
+if [ -f yarn.lock ]; then
+  echo "Installing dev dependencies with yarn..."
+  yarn add -D "${deps[@]}"
+else
+  echo "Installing dev dependencies with npm..."
+  npm install -D "${deps[@]}"
+fi
+
+echo "Dev dependencies installed."

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,6 +10,9 @@ else
   npm install
 fi
 
+# Install additional dev dependencies needed for linting and testing
+./scripts/install-dev-deps.sh
+
 if [ -f .env.example ] && [ ! -f .env ]; then
   cp .env.example .env
   echo "Copied .env.example to .env"

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('basic arithmetic works', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- install lint & test dev dependencies via script
- document dev setup and lint/test usage
- add Node.js sample test

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866e87444c08327a226d56beafc6fe3