### PR TITLE
Fix Netlify install by updating @types/react-dnd version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "@types/react-dnd": "^16.0.1",
+    "@types/react-dnd": "^16.0.2",
     "@types/pdfjs-dist": "^2.17.5"
   }
 }


### PR DESCRIPTION
## Summary
- bump `@types/react-dnd` to `^16.0.2` to match `react-dnd`

## Testing
- `npm test` *(fails: Missing script)*
- `yarn install` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6866fc38888c8327a00168c82fd9cbbe