### PR TITLE
Fix React DnD typings version

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3",
-    "@types/react-dnd": "^16.0.2",
+    "@types/react-dnd": "^15.0.2",
     "@types/pdfjs-dist": "^2.17.5"
   }
 }


### PR DESCRIPTION
## Summary
- fix dev dependency version for `@types/react-dnd`

## Testing
- `yarn install` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6866fe610b8883279e9d29ce54512f50