### PR TITLE
Fix ExperienceBadge props and update usages

### DIFF
--- a/app/admin/projects/details/[id]/page.tsx
+++ b/app/admin/projects/details/[id]/page.tsx
@@ -298,7 +298,7 @@ export default function AdminProjectDetail() {
                 <div className="pt-2 border-t">
                   <div className="flex justify-between">
                     <span>Minimum Badge:</span>
-                    <ExperienceBadge level={project.minimum_badge} />
+                    <ExperienceBadge badge={project.minimum_badge} />
                   </div>
                 </div>
               </div>
@@ -390,7 +390,7 @@ export default function AdminProjectDetail() {
                       </div>
                       <div>
                         <p className="font-medium">{talent.full_name}</p>
-                        <ExperienceBadge level={talent.experience_badge} />
+                        <ExperienceBadge badge={talent.experience_badge} />
                       </div>
                     </div>
                     <div className="space-y-2 text-sm">

--- a/app/admin/projects/details/page.tsx
+++ b/app/admin/projects/details/page.tsx
@@ -298,7 +298,7 @@ export default function AdminProjectDetail() {
                 <div className="pt-2 border-t">
                   <div className="flex justify-between">
                     <span>Minimum Badge:</span>
-                    <ExperienceBadge level={project.minimum_badge} />
+                    <ExperienceBadge badge={project.minimum_badge} />
                   </div>
                 </div>
               </div>
@@ -390,7 +390,7 @@ export default function AdminProjectDetail() {
                       </div>
                       <div>
                         <p className="font-medium">{talent.full_name}</p>
-                        <ExperienceBadge level={talent.experience_badge} />
+                        <ExperienceBadge badge={talent.experience_badge} />
                       </div>
                     </div>
                     <div className="space-y-2 text-sm">

--- a/components/ExperienceBadge.tsx
+++ b/components/ExperienceBadge.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import { Star, Trophy, Medal, Award } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip';
 
 interface Props {
-  level: string;
+  badge: string;
+  showTooltip?: boolean;
   className?: string;
 }
 
-export default function ExperienceBadge({ level, className }: Props) {
+export default function ExperienceBadge({ badge, showTooltip, className }: Props): JSX.Element {
   // Map database badge values to internal configuration
   const mapBadgeToLevel = (badge: string): 'entry' | 'mid' | 'expert' | 'elite' => {
     switch (badge?.toLowerCase()) {
@@ -56,10 +63,10 @@ export default function ExperienceBadge({ level, className }: Props) {
     },
   };
 
-  const mappedLevel = mapBadgeToLevel(level);
+  const mappedLevel = mapBadgeToLevel(badge);
   const { icon: Icon, label, baseClasses } = config[mappedLevel];
 
-  return (
+  const badgeElement = (
     <span
       className={cn(
         'inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium',
@@ -72,4 +79,17 @@ export default function ExperienceBadge({ level, className }: Props) {
       {label}
     </span>
   );
+
+  if (showTooltip) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{badgeElement}</TooltipTrigger>
+          <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return badgeElement;
 }

--- a/components/ProjectTemplateCard.tsx
+++ b/components/ProjectTemplateCard.tsx
@@ -43,7 +43,7 @@ export default function ProjectTemplateCard({ template, onSelect }: ProjectTempl
             </Badge>
             <h3 className="text-lg font-semibold mt-2">{template.title}</h3>
           </div>
-          <ExperienceBadge level={template.suggested_level} />
+          <ExperienceBadge badge={template.suggested_level} />
         </div>
 
         <p className="text-sm text-gray-600 mb-4">{template.description}</p>


### PR DESCRIPTION
## Summary
- update ExperienceBadge component to use `badge` and optional `showTooltip`
- add tooltip integration
- update all usages to the new prop

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bc8ccffbc832781159cd8494cae89