### PR TITLE
Fix CaseStudy modal typing

### DIFF
--- a/app/talent/dashboard/page.tsx
+++ b/app/talent/dashboard/page.tsx
@@ -38,6 +38,26 @@ interface CaseStudy {
   deliverableId?: string;
 }
 
+interface CaseStudyData {
+  title: string;
+  problem: string;
+  solution: string;
+  kpis: string;
+  results: string;
+  showOnPortfolio: boolean;
+}
+
+function toCaseStudyData(cs: CaseStudy): CaseStudyData {
+  return {
+    title: cs.summary ?? '',
+    problem: cs.summary ?? '',
+    solution: cs.outcome ?? '',
+    kpis: '',
+    results: cs.outcome ?? '',
+    showOnPortfolio: false,
+  };
+}
+
 interface Project {
   id: string;
   title: string;
@@ -226,9 +246,14 @@ export default function TalentDashboard() {
                   open={true}
                   onClose={() => setEditingProjectId(null)}
                   deliverables={project.deliverables || []}
-                  initialData={project.caseStudy}
+                  initialData={project.caseStudy ? toCaseStudyData(project.caseStudy) : undefined}
                   onSubmit={(newData) => {
-                    handleSaveCaseStudy(project.id, newData);
+                    handleSaveCaseStudy(project.id, {
+                      id: project.caseStudy?.id || '',
+                      summary: newData.problem || newData.title,
+                      outcome: newData.results || newData.solution,
+                      deliverableId: project.caseStudy?.deliverableId,
+                    });
                     setEditingProjectId(null);
                   }}
                 />

--- a/components/CaseStudyModal.tsx
+++ b/components/CaseStudyModal.tsx
@@ -24,11 +24,18 @@ export interface CaseStudyData {
   showOnPortfolio: boolean;
 }
 
+export interface CaseStudy {
+  id: string;
+  summary: string;
+  outcome: string;
+  deliverableId?: string;
+}
+
 interface CaseStudyModalProps {
   open: boolean;
   onClose: () => void;
   onSubmit: (data: CaseStudyData) => void;
-  initialData?: CaseStudyData;
+  initialData?: CaseStudyData | CaseStudy;
   deliverables?: Deliverable[];
 }
 
@@ -42,12 +49,22 @@ export default function CaseStudyModal({ open, onClose, onSubmit, initialData, d
 
   useEffect(() => {
     if (initialData) {
-      setTitle(initialData.title);
-      setProblem(initialData.problem);
-      setSolution(initialData.solution);
-      setKpis(initialData.kpis);
-      setResults(initialData.results);
-      setShowOnPortfolio(initialData.showOnPortfolio);
+      if ('title' in initialData) {
+        setTitle(initialData.title);
+        setProblem(initialData.problem);
+        setSolution(initialData.solution);
+        setKpis(initialData.kpis);
+        setResults(initialData.results);
+        setShowOnPortfolio(initialData.showOnPortfolio);
+      } else {
+        // Fallback mapping when provided with CaseStudy
+        setTitle(initialData.summary ?? '');
+        setProblem(initialData.summary ?? '');
+        setSolution(initialData.outcome ?? '');
+        setKpis('');
+        setResults(initialData.outcome ?? '');
+        setShowOnPortfolio(false);
+      }
     } else if (deliverables.length > 0) {
       const [first] = deliverables;
       setTitle(first.title);


### PR DESCRIPTION
## Summary
- extend `CaseStudyModal` to accept `CaseStudy` objects
- map older `CaseStudy` records to modal data shape
- convert data before passing to modal in dashboard page

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'drizzle-orm' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686bddcfc11c8327ae222d826a9f22b1