### PR TITLE
Fix Next.js POST handler signatures

### DIFF
--- a/app/api/clerk/webhook/route.ts
+++ b/app/api/clerk/webhook/route.ts
@@ -8,12 +8,12 @@ interface ClerkWebhookEvent {
   data: any;
 }
 
-export async function POST(req: NextRequest) {
-  const payload = await req.text();
+export async function POST(request: NextRequest) {
+  const payload = await request.text();
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 
   try {
-    const evt = wh.verify(payload, req.headers as any) as ClerkWebhookEvent;
+    const evt = wh.verify(payload, request.headers as any) as ClerkWebhookEvent;
     console.log('Clerk webhook event', evt.type);
 
     if (evt.type === 'user.created') {

--- a/app/api/clients/[id]/trust-score/route.ts
+++ b/app/api/clients/[id]/trust-score/route.ts
@@ -6,7 +6,7 @@ import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function POST(
-  _req: NextRequest,
+  request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   const { userId, sessionClaims } = auth();

--- a/app/api/talent/[id]/flag/route.ts
+++ b/app/api/talent/[id]/flag/route.ts
@@ -3,7 +3,7 @@ import { flagTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
   
   try {
-    const { reason } = await req.json();
+    const { reason } = await request.json();
     const data = await flagTalent(params.id, reason);
     return NextResponse.json({ data });
   } catch (error) {

--- a/app/api/talent/[id]/qualify/route.ts
+++ b/app/api/talent/[id]/qualify/route.ts
@@ -3,7 +3,7 @@ import { qualifyTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   }
   
   try {
-    const { qualified } = await req.json();
+    const { qualified } = await request.json();
     const data = await qualifyTalent(params.id, qualified);
     return NextResponse.json({ data });
   } catch (error) {

--- a/app/api/talent/[id]/trust-score/route.ts
+++ b/app/api/talent/[id]/trust-score/route.ts
@@ -3,7 +3,7 @@ import { updateTalentTrustScore } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   


### PR DESCRIPTION
## Summary
- standardize POST handler parameter names to `request`
- update dynamic API routes to match Next.js convention

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-refresh')*

------
https://chatgpt.com/codex/tasks/task_e_686bffae953c8327ad2843dc0bea35be