### PR TITLE
Fix React namespace errors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ClerkProvider } from '@clerk/nextjs';
 import { Toaster } from '@/components/ui/sonner';
 import '@/styles/globals.css';

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';

--- a/app/waitlist/page.tsx
+++ b/app/waitlist/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";


### PR DESCRIPTION
## Summary
- import React in pages using React types
- ensure layout.tsx has explicit React import

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'drizzle-orm/neon-http' and others)*

------
https://chatgpt.com/codex/tasks/task_e_686c06b245f083278e5231a36946fc38