### PR TITLE
Fix React typings by removing custom shim

### DIFF
--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -1,14 +1,12 @@
 'use client';
 import * as React from 'react';
 import { ArrowLeftIcon, ArrowRightIcon } from '@radix-ui/react-icons';
-import useEmblaCarousel, {
-  type UseEmblaCarouselType,
-} from 'embla-carousel-react';
+import useEmblaCarousel from 'embla-carousel-react';
 
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
-type CarouselApi = UseEmblaCarouselType[1];
+type CarouselApi = ReturnType<typeof useEmblaCarousel>[1];
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
 type CarouselOptions = UseCarouselParameters[0];
 type CarouselPlugin = UseCarouselParameters[1];

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -16,10 +16,11 @@ const ToggleGroup = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Root> &
     VariantProps<typeof toggleVariants>
->(({ className, variant, size, children, ...props }, ref) => (
+>(({ className, variant, size, children, type = 'single', ...props }, ref) => (
   <ToggleGroupPrimitive.Root
     ref={ref}
     className={cn('flex items-center justify-center gap-1', className)}
+    type={type}
     {...props}
   >
     <ToggleGroupContext.Provider value={{ variant, size }}>
@@ -34,12 +35,13 @@ const ToggleGroupItem = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof ToggleGroupPrimitive.Item> &
     VariantProps<typeof toggleVariants>
->(({ className, children, variant, size, ...props }, ref) => {
+>(({ className, children, variant, size, value, ...props }, ref) => {
   const context = React.useContext(ToggleGroupContext);
 
   return (
     <ToggleGroupPrimitive.Item
       ref={ref}
+      value={value}
       className={cn(
         toggleVariants({
           variant: context.variant || variant,

--- a/types/shims.d.ts
+++ b/types/shims.d.ts
@@ -3,47 +3,6 @@ declare module 'react-dnd-html5-backend';
 declare module 'react-day-picker';
 declare module 'pdfjs-dist';
 
-declare module 'react' {
-  export as namespace React;
-  export type ReactNode = any;
-  export interface HTMLAttributes<T> {
-    [key: string]: any;
-    className?: string;
-  }
-  export interface FC<P = {}> {
-    (props: P): ReactNode;
-  }
-  export type ChangeEvent<T = any> = any;
-  export type FormEvent<T = any> = any;
-  export type ElementRef<T = any> = any;
-  export function useState<T = any>(
-    initial: T
-  ): [T, (value: T | ((prev: T) => T)) => void];
-  export function useEffect(...args: any[]): void;
-  export const useContext: any;
-  export const useRef: any;
-  export const useCallback: any;
-  export const useMemo: any;
-  export const useReducer: any;
-  export const useLayoutEffect: any;
-  export const createContext: any;
-  export const forwardRef: any;
-  const React: any;
-  export default React;
-  export = React;
-}
-
-declare var React: any;
-
-declare namespace JSX {
-  interface IntrinsicAttributes {
-    key?: any;
-  }
-  interface IntrinsicElements {
-    [elemName: string]: any;
-  }
-  interface Element {}
-}
 
 declare module '@clerk/nextjs';
 declare module '@clerk/nextjs/server';
@@ -62,7 +21,6 @@ declare module 'lucide-react';
 declare module 'sonner';
 declare module 'date-fns';
 declare module 'svix';
-declare module 'clsx';
 declare module 'drizzle-orm';
 declare module '@neondatabase/serverless';
 declare module '@radix-ui/*';
@@ -72,13 +30,8 @@ declare module 'class-variance-authority' {
   export type VariantProps<T> = any;
 }
 
-declare module 'embla-carousel-react';
-declare module 'recharts';
-declare module 'recharts/types/component/DefaultTooltipContent';
 declare module 'cmdk';
 declare module 'vaul';
-declare module 'react-hook-form';
-declare module 'input-otp';
 declare module 'react-resizable-panels';
 declare module 'drizzle-kit';
 declare module 'dotenv';


### PR DESCRIPTION
## Summary
- remove custom React declarations from `types/shims.d.ts`
- drop unused stubs for several packages
- update carousel component to rely on library types
- adjust toggle group defaults

## Testing
- `npx tsc --noEmit` *(passed earlier)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-refresh')*

------
https://chatgpt.com/codex/tasks/task_e_686c0956d5448327bc5c02a3836d7bdf