### PR TITLE
Fix route handler typings

### DIFF
--- a/app/api/admin/projects/route.ts
+++ b/app/api/admin/projects/route.ts
@@ -9,7 +9,7 @@ type SessionClaimsWithRole = {
   };
 };
 
-export async function GET(_req: NextRequest) {
+export async function GET(_req: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,5 +1,5 @@
 import { auth } from "@clerk/nextjs/server";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 type SessionClaimsWithRole = {
   metadata?: {
@@ -9,7 +9,7 @@ type SessionClaimsWithRole = {
 
 export const runtime = 'nodejs'; // ⛔ Clerk not supported on Edge runtime
 
-export async function GET() {
+export async function GET(_req: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
 
   // ✅ Safely extract role

--- a/app/api/admin/talent/trust_score/recalculate-all/route.ts
+++ b/app/api/admin/talent/trust_score/recalculate-all/route.ts
@@ -1,5 +1,5 @@
 import { recalculateAllTrustScores } from '@/lib/apiHandlers/admin';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@clerk/nextjs';
 
 type SessionClaimsWithRole = {
@@ -8,7 +8,7 @@ type SessionClaimsWithRole = {
   };
 };
 
-export async function POST() {
+export async function POST(_req: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 

--- a/app/api/clerk/webhook/route.ts
+++ b/app/api/clerk/webhook/route.ts
@@ -8,7 +8,7 @@ interface ClerkWebhookEvent {
   data: any;
 }
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest, _ctx: { params: {} }) {
   const payload = await request.text();
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -1,11 +1,11 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function GET() {
+export async function GET(_req: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 

--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -5,7 +5,7 @@ import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function GET(request: NextRequest) {
+export async function GET(request: NextRequest, _ctx: { params: {} }) {
   const { userId } = auth();
   
   // Check if user is authenticated
@@ -60,7 +60,7 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function POST(request: NextRequest) {
+export async function POST(request: NextRequest, _ctx: { params: {} }) {
   const { userId } = auth();
   
   // Check if user is authenticated
@@ -101,7 +101,7 @@ export async function POST(request: NextRequest) {
   }
 }
 
-export async function PUT(request: NextRequest) {
+export async function PUT(request: NextRequest, _ctx: { params: {} }) {
   const { userId } = auth();
   
   // Check if user is authenticated
@@ -142,7 +142,7 @@ export async function PUT(request: NextRequest) {
   }
 }
 
-export async function DELETE(request: NextRequest) {
+export async function DELETE(request: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,7 +1,7 @@
 import { auth } from '@clerk/nextjs/server';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET() {
+export async function GET(_req: NextRequest, _ctx: { params: {} }) {
   const { userId, sessionClaims } = auth();
 
   // Cast to ensure TypeScript knows the shape of sessionClaims.metadata


### PR DESCRIPTION
## Summary
- normalize Next.js route handler signatures
- add missing `NextRequest` imports for API routes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c0e9f64c88327bde47b19094c0043