### PR TITLE
Fix dynamic route handler param types

### DIFF
--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -3,7 +3,10 @@ import { NextResponse, NextRequest } from 'next/server';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_req: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -14,14 +17,14 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   
   // Check if user is admin or the client themselves
   const isAdmin = role === 'admin';
-  const isOwnProfile = userId === params.id;
+  const isOwnProfile = userId === id;
   
   if (!isAdmin && !isOwnProfile) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
   
   try {
-    const projects = await getClientProjects(params.id);
+    const projects = await getClientProjects(id);
     return NextResponse.json({ projects });
   } catch (error) {
     console.error('Error fetching client projects:', error);

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -8,7 +8,10 @@ type SessionClaimsWithRole = {
   };
 };
 
-export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_req: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -19,14 +22,14 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   
   // Check if user is admin or the client themselves
   const isAdmin = role === 'admin';
-  const isOwnProfile = userId === params.id;
+  const isOwnProfile = userId === id;
   
   if (!isAdmin && !isOwnProfile) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
   
   try {
-    const client = await getClientById(params.id);
+    const client = await getClientById(id);
     return client
       ? NextResponse.json({ client })
       : NextResponse.json({ error: 'Client not found' }, { status: 404 });

--- a/app/api/clients/[id]/trust-score/route.ts
+++ b/app/api/clients/[id]/trust-score/route.ts
@@ -5,10 +5,13 @@ import { eq } from 'drizzle-orm';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
+type RouteContext = { params: Promise<{ id: string }> };
+
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  ctx: RouteContext
 ) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -22,7 +25,7 @@ export async function POST(
     await db
       .update(users)
       .set({ trustScore: score, updatedAt: new Date() })
-      .where(eq(users.id, params.id));
+      .where(eq(users.id, id));
     return NextResponse.json({ success: true, score });
   } catch (err) {
     console.error('Update trust score error', err);

--- a/app/api/talent/[id]/flag/route.ts
+++ b/app/api/talent/[id]/flag/route.ts
@@ -3,7 +3,10 @@ import { flagTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -14,7 +17,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
   
   try {
     const { reason } = await request.json();
-    const data = await flagTalent(params.id, reason);
+    const data = await flagTalent(id, reason);
     return NextResponse.json({ data });
   } catch (error) {
     console.error('Error flagging talent:', error);

--- a/app/api/talent/[id]/qualify/route.ts
+++ b/app/api/talent/[id]/qualify/route.ts
@@ -3,7 +3,10 @@ import { qualifyTalent } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -14,7 +17,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
   
   try {
     const { qualified } = await request.json();
-    const data = await qualifyTalent(params.id, qualified);
+    const data = await qualifyTalent(id, qualified);
     return NextResponse.json({ data });
   } catch (error) {
     console.error('Error updating talent qualification:', error);

--- a/app/api/talent/[id]/trust-score/route.ts
+++ b/app/api/talent/[id]/trust-score/route.ts
@@ -3,7 +3,10 @@ import { updateTalentTrustScore } from '@/lib/apiHandlers/talent';
 import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
-export async function POST(request: NextRequest, { params }: { params: { id: string } }) {
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(request: NextRequest, ctx: RouteContext) {
+  const { id } = await ctx.params;
   const { userId, sessionClaims } = auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
@@ -13,7 +16,7 @@ export async function POST(request: NextRequest, { params }: { params: { id: str
   }
   
   try {
-    const data = await updateTalentTrustScore(params.id);
+    const data = await updateTalentTrustScore(id);
     return NextResponse.json({ data });
   } catch (error) {
     console.error('Error updating trust score:', error);


### PR DESCRIPTION
## Summary
- update dynamic API routes to use async `params` context

## Testing
- `npx tsc --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c32b745708327aded1d816e8bc2ec