### PR TITLE
Adjust sign-in redirect

### DIFF
--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -26,9 +26,8 @@ export default function SignInPage() {
               footerActionLink: "text-[#2E3A8C] hover:text-[#2E3A8C]/90"
             }
           }}
-          redirectUrl="/dashboard"
+          redirectUrl="/talent/dashboard"
         />
       </div>
     </main>
-  );
-}
+  );}

--- a/components/SignInForm.tsx
+++ b/components/SignInForm.tsx
@@ -2,6 +2,6 @@
 import { SignIn } from '@clerk/nextjs';
 
 export function SignInForm() {
-  return <SignIn redirectUrl="/dashboard" />;
+  return <SignIn redirectUrl="/talent/dashboard" />;
 }
 


### PR DESCRIPTION
## Summary
- route sign-in to `/talent/dashboard`
- update sign-in form redirect

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686e88b086108327b7362d1ba83a908b