### PR TITLE
Fix header usage and middleware redirect loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 .pnpm/
 
 # Build output
+# Next.js builds will generate a `.next/` directory.
+# It contains compiled assets and should never be committed.
 .next/
 out/              # if using `next export`
 dist/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm run dev
 yarn dev
 ```
 
+When working in cloud IDEs such as StackBlitz or Codesandbox, you may see a `.next/` folder created after running the dev server. This directory contains build artifacts and is already listed in `.gitignore`, so it can safely be removed or ignored.
+
 ## Mock User Credentials
 
 All mock users have the password: `password123`

--- a/app/api/clerk/webhook/route.ts
+++ b/app/api/clerk/webhook/route.ts
@@ -13,7 +13,12 @@ export async function POST(request: NextRequest) {
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 
   try {
-    const evt = wh.verify(payload, request.headers as any) as ClerkWebhookEvent;
+    const headers = {
+      'svix-id': request.headers.get('svix-id') || '',
+      'svix-timestamp': request.headers.get('svix-timestamp') || '',
+      'svix-signature': request.headers.get('svix-signature') || '',
+    };
+    const evt = wh.verify(payload, headers) as ClerkWebhookEvent;
     console.log('Clerk webhook event', evt.type);
 
     if (evt.type === 'user.created') {

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,13 @@ export default authMiddleware({
     const role = (auth.sessionClaims as SessionClaimsWithRole)?.metadata?.role as string | undefined;
     const pathname = req.nextUrl.pathname;
 
+    if (!role) {
+      if (pathname !== '/waitlist') {
+        return NextResponse.redirect(new URL('/waitlist', req.url));
+      }
+      return NextResponse.next();
+    }
+
     if (pathname.startsWith('/admin') && role !== 'admin') {
       return NextResponse.redirect(new URL('/', req.url));
     }


### PR DESCRIPTION
## Summary
- document ignoring `.next/` directory
- clarify `.gitignore` entry for `.next/`
- guard middleware to send roleless users to `/waitlist`
- verify webhook signatures using `headers().get()` pattern

## Testing
- `npm run lint`
- `npm run build` *(fails: DATABASE_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686e99aedab4832789c2f600e3410d7b