### PR TITLE
Fix header usage and route guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ node_modules/
 .pnpm/
 
 # Build output
+# Next.js builds will generate a `.next/` directory.
+# It contains compiled assets and should never be committed.
 .next/
 out/              # if using `next export`
 dist/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ npm run dev
 yarn dev
 ```
 
+When working in cloud IDEs such as StackBlitz or Codesandbox, you may see a `.next/` folder created after running the dev server. This directory contains build artifacts and is already listed in `.gitignore`, so it can safely be removed or ignored.
+
 ## Mock User Credentials
 
 All mock users have the password: `password123`

--- a/app/api/clerk/webhook/route.ts
+++ b/app/api/clerk/webhook/route.ts
@@ -13,7 +13,12 @@ export async function POST(request: NextRequest) {
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 
   try {
-    const evt = wh.verify(payload, request.headers as any) as ClerkWebhookEvent;
+    const headers = {
+      'svix-id': request.headers.get('svix-id') || '',
+      'svix-timestamp': request.headers.get('svix-timestamp') || '',
+      'svix-signature': request.headers.get('svix-signature') || '',
+    };
+    const evt = wh.verify(payload, headers) as ClerkWebhookEvent;
     console.log('Clerk webhook event', evt.type);
 
     if (evt.type === 'user.created') {

--- a/components/routing/AdminRoute.tsx
+++ b/components/routing/AdminRoute.tsx
@@ -1,6 +1,7 @@
-'use client';
-import { useUser } from '@clerk/nextjs';
-import { redirect } from 'next/navigation';
+"use client";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 interface AdminRouteProps {
   children: React.ReactNode;
@@ -8,14 +9,25 @@ interface AdminRouteProps {
 
 export default function AdminRoute({ children }: AdminRouteProps) {
   const { isSignedIn, isLoaded, user } = useUser();
-  const isAdmin = user?.publicMetadata?.role === 'admin';
+  const router = useRouter();
+  const role = user?.publicMetadata?.role as string | undefined;
+
+  useEffect(() => {
+    if (isLoaded && (!isSignedIn || role !== "admin")) {
+      router.replace("/");
+    }
+  }, [isLoaded, isSignedIn, role, router]);
 
   if (!isLoaded) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    );
   }
 
-  if (!isSignedIn || !isAdmin) {
-    redirect('/');
+  if (!isSignedIn || role !== "admin") {
+    return null;
   }
 
   return <>{children}</>;

--- a/components/routing/PrivateRoute.tsx
+++ b/components/routing/PrivateRoute.tsx
@@ -1,6 +1,7 @@
-'use client';
-import { useUser } from '@clerk/nextjs';
-import { redirect } from 'next/navigation';
+"use client";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 interface PrivateRouteProps {
   children: React.ReactNode;
@@ -8,13 +9,24 @@ interface PrivateRouteProps {
 
 export default function PrivateRoute({ children }: PrivateRouteProps) {
   const { isSignedIn, isLoaded } = useUser();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) {
+      router.replace("/sign-in");
+    }
+  }, [isLoaded, isSignedIn, router]);
 
   if (!isLoaded) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Loading...
+      </div>
+    );
   }
 
   if (!isSignedIn) {
-    redirect('/sign-in');
+    return null;
   }
 
   return <>{children}</>;

--- a/components/routing/RoleRoute.tsx
+++ b/components/routing/RoleRoute.tsx
@@ -1,6 +1,7 @@
-'use client';
-import { useUser } from '@clerk/nextjs';
-import { redirect } from 'next/navigation';
+"use client";
+import { useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 interface RoleRouteProps {
   allowedRoles: string[];
@@ -9,16 +10,30 @@ interface RoleRouteProps {
 
 export default function RoleRoute({ allowedRoles, children }: RoleRouteProps) {
   const { isSignedIn, isLoaded, user } = useUser();
-  const userRole = user?.publicMetadata?.role as string;
+  const router = useRouter();
+  const role = user?.publicMetadata?.role as string | undefined;
 
-  if (!isLoaded) {
-    return <div className="flex items-center justify-center min-h-screen">Loading...</div>;
+  useEffect(() => {
+    if (isLoaded && isSignedIn && role && !allowedRoles.includes(role)) {
+      router.replace("/sign-in");
+    }
+  }, [isLoaded, isSignedIn, role, allowedRoles, router]);
+
+  if (!isLoaded || !role) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        Checking permissions...
+      </div>
+    );
   }
 
-  const hasAccess = isSignedIn && allowedRoles.includes(userRole);
+  if (!isSignedIn) {
+    router.replace("/sign-in");
+    return null;
+  }
 
-  if (!hasAccess) {
-    redirect('/sign-in');
+  if (!allowedRoles.includes(role)) {
+    return null;
   }
 
   return <>{children}</>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,13 @@ export default authMiddleware({
     const role = (auth.sessionClaims as SessionClaimsWithRole)?.metadata?.role as string | undefined;
     const pathname = req.nextUrl.pathname;
 
+    if (!role) {
+      if (pathname !== '/waitlist') {
+        return NextResponse.redirect(new URL('/waitlist', req.url));
+      }
+      return NextResponse.next();
+    }
+
     if (pathname.startsWith('/admin') && role !== 'admin') {
       return NextResponse.redirect(new URL('/', req.url));
     }


### PR DESCRIPTION
## Summary
- document ignoring `.next/` directory
- use `request.headers.get()` when verifying Clerk webhooks
- redirect roleless visitors to `/waitlist`
- switch route guards to client-side redirects

## Testing
- `npm run lint`
- `npm run build` *(fails: DATABASE_URL is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_686e99aedab4832789c2f600e3410d7b