### PR TITLE
Fix auth calls in API routes

### DIFF
--- a/app/api/admin/projects/route.ts
+++ b/app/api/admin/projects/route.ts
@@ -10,7 +10,7 @@ type SessionClaimsWithRole = {
 };
 
 export async function GET(_req: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 
   // Check if user is authenticated and has admin role

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -10,7 +10,7 @@ type SessionClaimsWithRole = {
 export const runtime = 'nodejs'; // ⛔ Clerk not supported on Edge runtime
 
 export async function GET(_req: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
 
   // ✅ Safely extract role
   const userRole = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;

--- a/app/api/admin/talent/trust_score/recalculate-all/route.ts
+++ b/app/api/admin/talent/trust_score/recalculate-all/route.ts
@@ -9,7 +9,7 @@ type SessionClaimsWithRole = {
 };
 
 export async function POST(_req: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 
   // Check if user is authenticated and has admin role

--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -7,7 +7,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_req: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -12,7 +12,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function GET(_req: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated

--- a/app/api/clients/[id]/trust-score/route.ts
+++ b/app/api/clients/[id]/trust-score/route.ts
@@ -12,7 +12,7 @@ export async function POST(
   ctx: RouteContext
 ) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -6,7 +6,7 @@ import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(_req: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 
   // Check if user is authenticated and has admin role

--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -6,7 +6,7 @@ import { auth } from '@clerk/nextjs';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(request: NextRequest) {
-  const { userId } = auth();
+  const { userId } = await auth();
   
   // Check if user is authenticated
   if (!userId) {
@@ -61,7 +61,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const { userId } = auth();
+  const { userId } = await auth();
   
   // Check if user is authenticated
   if (!userId) {
@@ -102,7 +102,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function PUT(request: NextRequest) {
-  const { userId } = auth();
+  const { userId } = await auth();
   
   // Check if user is authenticated
   if (!userId) {
@@ -143,7 +143,7 @@ export async function PUT(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,7 +2,7 @@ import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(_req: NextRequest) {
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
 
   // Cast to ensure TypeScript knows the shape of sessionClaims.metadata
   const role = (sessionClaims?.metadata as { role?: string })?.role;

--- a/app/api/talent/[id]/flag/route.ts
+++ b/app/api/talent/[id]/flag/route.ts
@@ -7,7 +7,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role

--- a/app/api/talent/[id]/qualify/route.ts
+++ b/app/api/talent/[id]/qualify/route.ts
@@ -7,7 +7,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role

--- a/app/api/talent/[id]/trust-score/route.ts
+++ b/app/api/talent/[id]/trust-score/route.ts
@@ -7,7 +7,7 @@ type RouteContext = { params: Promise<{ id: string }> };
 
 export async function POST(request: NextRequest, ctx: RouteContext) {
   const { id } = await ctx.params;
-  const { userId, sessionClaims } = auth();
+  const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
   
   // Check if user is authenticated and has admin role


### PR DESCRIPTION
## Summary
- await all `auth()` calls in API routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ead36e85883278af63545badb6618