### PR TITLE
Fix Clerk auth imports

### DIFF
--- a/app/api/admin/projects/route.ts
+++ b/app/api/admin/projects/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { projects } from '@/lib/schema';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 
 type SessionClaimsWithRole = {
   metadata?: {

--- a/app/api/admin/talent/trust_score/recalculate-all/route.ts
+++ b/app/api/admin/talent/trust_score/recalculate-all/route.ts
@@ -1,6 +1,6 @@
 import { recalculateAllTrustScores } from '@/lib/apiHandlers/admin';
 import { NextRequest, NextResponse } from 'next/server';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 
 type SessionClaimsWithRole = {
   metadata?: {

--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -1,6 +1,6 @@
 import { getClientProjects } from '@/lib/apiHandlers/clients';
 import { NextResponse, NextRequest } from 'next/server';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };

--- a/app/api/clients/[id]/route.ts
+++ b/app/api/clients/[id]/route.ts
@@ -1,6 +1,6 @@
 import { getClientById } from '@/lib/apiHandlers/clients';
 import { NextResponse, NextRequest } from 'next/server';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 
 type SessionClaimsWithRole = {
   metadata?: {

--- a/app/api/clients/[id]/trust-score/route.ts
+++ b/app/api/clients/[id]/trust-score/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(_req: NextRequest) {

--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
 import { users, projects, talentProfiles } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 export async function GET(request: NextRequest) {

--- a/app/api/talent/[id]/flag/route.ts
+++ b/app/api/talent/[id]/flag/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { flagTalent } from '@/lib/apiHandlers/talent';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };

--- a/app/api/talent/[id]/qualify/route.ts
+++ b/app/api/talent/[id]/qualify/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { qualifyTalent } from '@/lib/apiHandlers/talent';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };

--- a/app/api/talent/[id]/trust-score/route.ts
+++ b/app/api/talent/[id]/trust-score/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, NextRequest } from 'next/server';
 import { updateTalentTrustScore } from '@/lib/apiHandlers/talent';
-import { auth } from '@clerk/nextjs';
+import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };


### PR DESCRIPTION
## Summary
- use `@clerk/nextjs/server` for auth in API routes

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686ea8f3077483279bb4aafdb2c37ee6