### PR TITLE
Fix webhook header async access

### DIFF
--- a/app/api/clerk/webhook/route.ts
+++ b/app/api/clerk/webhook/route.ts
@@ -13,10 +13,11 @@ export async function POST(request: NextRequest) {
   const wh = new Webhook(process.env.CLERK_WEBHOOK_SECRET || '');
 
   try {
+    const headerList = await request.headers;
     const headers = {
-      'svix-id': request.headers.get('svix-id') || '',
-      'svix-timestamp': request.headers.get('svix-timestamp') || '',
-      'svix-signature': request.headers.get('svix-signature') || '',
+      'svix-id': headerList.get('svix-id') || '',
+      'svix-timestamp': headerList.get('svix-timestamp') || '',
+      'svix-signature': headerList.get('svix-signature') || '',
     };
     const evt = wh.verify(payload, headers) as ClerkWebhookEvent;
     console.log('Clerk webhook event', evt.type);


### PR DESCRIPTION
## Summary
- fix `request.headers` access in Clerk webhook handler

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686ebc8a97dc8327afea037a49a50974