### PR TITLE
Remove supabase client

### DIFF
--- a/app/talent/dashboard/page.tsx
+++ b/app/talent/dashboard/page.tsx
@@ -5,7 +5,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
-import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/lib/useAuth";
 import {
   Clock,

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,1 +1,0 @@
-export const supabase = {} as any;


### PR DESCRIPTION
## Summary
- delete `supabaseClient` shim
- stop importing supabase client on the talent dashboard page

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb660ff48327b4df4a5c3f039343