### PR TITLE
Remove Supabase references and enforce guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npm run type-check",
+    "prebuild": "npm run check-supabase && npm run type-check",
     "build": "next build",
+    "check-supabase": "node scripts/check-no-supabase.cjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "start": "next start",

--- a/scripts/check-no-supabase.cjs
+++ b/scripts/check-no-supabase.cjs
@@ -1,0 +1,29 @@
+const { execSync } = require('child_process');
+
+const patterns = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY',
+  'createClient',
+  '@supabase/supabase-js',
+  'supabaseClient'
+];
+
+const globs = "--include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx'";
+
+let found = false;
+patterns.forEach((pattern) => {
+  try {
+    const result = execSync(`grep -R ${globs} --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=.next "${pattern}"`, { encoding: 'utf8' });
+    if (result.trim()) {
+      console.error(`Forbidden Supabase reference found for pattern "${pattern}":\n${result}`);
+      found = true;
+    }
+  } catch (err) {
+    // grep exits with code 1 when no matches are found; ignore
+  }
+});
+
+if (found) {
+  console.error('Supabase references are not allowed.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- ensure no Supabase packages remain
- add build-time guard to fail if any Supabase code is referenced

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run check-supabase`

------
https://chatgpt.com/codex/tasks/task_e_686ef55f34b08327a403fe61897b74e2