### PR TITLE
Audit clerk imports, update configs and cleanup build

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -40,7 +40,7 @@ export default authMiddleware({
     }
 
     const validRoles = ['admin', 'client', 'talent'];
-    if (!validRoles.includes(role)) {
+    if (!role || !validRoles.includes(role)) {
       return NextResponse.next();
     }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,5 +18,3 @@
   Referrer-Policy = "strict-origin-when-cross-origin"
   Content-Security-Policy = "default-src 'self' https://app.adhokpro.com; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';"
 
-[[plugins]]
-  package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npm run check-supabase && npm run type-check",
+    "prebuild": "npm run check-lockfile && npm run check-netlify && npm run check-supabase && npm run type-check",
     "build": "next build",
     "check-supabase": "node scripts/check-no-supabase.cjs",
     "type-check": "tsc --noEmit",
@@ -20,14 +20,21 @@
     "seed-auth": "node --import dotenv/config scripts/seed-auth-users.js",
     "backfill-missing-ids": "node --import dotenv/config scripts/backfillMissingProjectIds.js",
     "recalculate-trust-scores": "node --import dotenv/config scripts/recalculateTrustScores.js",
-    "process-brief": "node scripts/processBrief.js"
+    "process-brief": "node scripts/processBrief.js",
+    "check-lockfile": "yarn install --immutable --immutable-cache --check-cache",
+    "check-netlify": "node scripts/check-no-netlify-plugin.cjs",
+    "postinstall": "node scripts/postinstall-cleanup.cjs"
+  },
+  "resolutions": {
+    "@types/pg": "8.11.6",
+    "@types/node": "20.11.17",
+    "@clerk/types": "3.65.5"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.31.8",
     "@clerk/types": "^3.65.5",
     "@hookform/resolvers": "^3.3.4",
     "@neondatabase/serverless": "^0.9.0",
-    "@netlify/plugin-nextjs": "^5.8.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",

--- a/scripts/check-no-netlify-plugin.cjs
+++ b/scripts/check-no-netlify-plugin.cjs
@@ -1,0 +1,5 @@
+const pkg = require('../package.json');
+if (pkg.dependencies && pkg.dependencies['@netlify/plugin-nextjs']) {
+  console.error('Forbidden dependency @netlify/plugin-nextjs detected');
+  process.exit(1);
+}

--- a/scripts/postinstall-cleanup.cjs
+++ b/scripts/postinstall-cleanup.cjs
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const paths = [
+  'node_modules/drizzle-orm/mysql-core',
+  'node_modules/drizzle-orm/sqlite-core',
+  'node_modules/bun-types'
+];
+paths.forEach((p) => {
+  if (fs.existsSync(p)) {
+    fs.rmSync(p, { recursive: true, force: true });
+    console.log(`Removed ${p}`);
+  }
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "@clerk/nextjs"],
 
     /* Linting */
     "strict": true,
@@ -37,5 +37,11 @@
     "app/api",
     "scripts",
     "middleware.ts"
+  ]
+  ,
+  "exclude": [
+    "node_modules/drizzle-orm/mysql-core",
+    "node_modules/drizzle-orm/sqlite-core",
+    "node_modules/bun-types"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,8 @@
     },
     "types": [
       "react",
-      "react-dom"
+      "react-dom",
+      "@clerk/nextjs"
     ]
   },
   "include": [
@@ -73,6 +74,9 @@
     "types/**/*.d.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "node_modules/drizzle-orm/mysql-core",
+    "node_modules/drizzle-orm/sqlite-core",
+    "node_modules/bun-types"
   ]
 }


### PR DESCRIPTION
## Summary
- add package resolutions for consistent types
- run lockfile checks and forbid Netlify plugin in prebuild
- wipe unneeded drizzle submodules after install
- ignore drizzle mysql/sqlite types via tsconfig excludes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: Cannot find type definition file for '@clerk/nextjs')*
- `yarn why drizzle-orm` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686ff0cb1d24832780418bcaefec6ea0