### PR TITLE
Audit clerk imports, refine tsconfig & cleanup script

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -40,7 +40,7 @@ export default authMiddleware({
     }
 
     const validRoles = ['admin', 'client', 'talent'];
-    if (!validRoles.includes(role)) {
+    if (!role || !validRoles.includes(role)) {
       return NextResponse.next();
     }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,5 +18,3 @@
   Referrer-Policy = "strict-origin-when-cross-origin"
   Content-Security-Policy = "default-src 'self' https://app.adhokpro.com; img-src 'self' data: https:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';"
 
-[[plugins]]
-  package = "@netlify/plugin-nextjs"

--- a/package.json
+++ b/package.json
@@ -20,14 +20,17 @@
     "seed-auth": "node --import dotenv/config scripts/seed-auth-users.js",
     "backfill-missing-ids": "node --import dotenv/config scripts/backfillMissingProjectIds.js",
     "recalculate-trust-scores": "node --import dotenv/config scripts/recalculateTrustScores.js",
-    "process-brief": "node scripts/processBrief.js"
+    "process-brief": "node scripts/processBrief.js",
+    "postinstall": "node scripts/postinstall-cleanup.js",
+    "preinstall": "node scripts/check-banned-packages.cjs",
+    "check-lockfile": "yarn install --immutable --check-cache",
+    "verify": "npm run lint && npm run type-check && npm run check-lockfile"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.31.8",
     "@clerk/types": "^3.65.5",
     "@hookform/resolvers": "^3.3.4",
     "@neondatabase/serverless": "^0.9.0",
-    "@netlify/plugin-nextjs": "^5.8.0",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.3",
@@ -98,5 +101,10 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.3"
+  },
+  "resolutions": {
+    "@types/node": "20.17.50",
+    "@types/pg": "8.15.4",
+    "@clerk/types": "3.65.5"
   }
 }

--- a/scripts/check-banned-packages.cjs
+++ b/scripts/check-banned-packages.cjs
@@ -1,0 +1,11 @@
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json','utf8'));
+const banned = ['@netlify/plugin-nextjs'];
+const found = banned.filter(dep =>
+  (pkg.dependencies && pkg.dependencies[dep]) ||
+  (pkg.devDependencies && pkg.devDependencies[dep])
+);
+if (found.length) {
+  console.error(`Forbidden packages detected: ${found.join(', ')}`);
+  process.exit(1);
+}

--- a/scripts/postinstall-cleanup.js
+++ b/scripts/postinstall-cleanup.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const paths = [
+  'node_modules/drizzle-orm/mysql-core',
+  'node_modules/drizzle-orm/sqlite-core',
+  'node_modules/bun-types',
+  'node_modules/@netlify/plugin-nextjs'
+];
+paths.forEach(p => {
+  try {
+    fs.rmSync(p, { recursive: true, force: true });
+  } catch (e) {
+    // ignore errors
+  }
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "types": ["react", "react-dom"],
+    "types": ["react", "react-dom", "@clerk/nextjs"],
 
     /* Linting */
     "strict": true,
@@ -37,5 +37,10 @@
     "app/api",
     "scripts",
     "middleware.ts"
+  ],
+  "exclude": [
+    "node_modules/drizzle-orm/mysql-core",
+    "node_modules/drizzle-orm/sqlite-core",
+    "node_modules/bun-types"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,8 @@
     },
     "types": [
       "react",
-      "react-dom"
+      "react-dom",
+      "@clerk/nextjs"
     ]
   },
   "include": [
@@ -73,6 +74,10 @@
     "types/**/*.d.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "node_modules/drizzle-orm/mysql-core",
+    "node_modules/drizzle-orm/sqlite-core",
+    "node_modules/bun-types",
+    "node_modules/pg-protocol/dist/messages"
   ]
 }


### PR DESCRIPTION
## Summary
- add postinstall cleanup script removing unused drizzle packages
- forbid installing @netlify/plugin-nextjs via preinstall check
- pin type packages with `resolutions`
- exclude unwanted node_modules paths in tsconfigs
- add lockfile verification script

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npm run type-check` *(fails: missing type packages)*
- `npm run check-lockfile` *(fails: network blocked)*
- `yarn why drizzle-orm` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686ff0cb1d24832780418bcaefec6ea0