### PR TITLE
Refactor postinstall cleanup to ESM

### DIFF
--- a/scripts/postinstall-cleanup.js
+++ b/scripts/postinstall-cleanup.js
@@ -1,15 +1,32 @@
 #!/usr/bin/env node
-const fs = require('fs');
+import { rmSync } from 'fs';
+
+const MIN_NODE_MAJOR = 18;
+const currentMajor = parseInt(process.versions.node.split('.')[0], 10);
+
+if (currentMajor < MIN_NODE_MAJOR) {
+  console.warn(
+    `[postinstall-cleanup] Node ${MIN_NODE_MAJOR}+ required. Detected ${process.version}.`
+  );
+}
+
+if (process.mainModule) {
+  console.warn(
+    '[postinstall-cleanup] Expected ESM context but running as CommonJS.'
+  );
+}
+
 const paths = [
   'node_modules/drizzle-orm/mysql-core',
   'node_modules/drizzle-orm/sqlite-core',
   'node_modules/bun-types',
   'node_modules/@netlify/plugin-nextjs'
 ];
-paths.forEach(p => {
+
+for (const p of paths) {
   try {
-    fs.rmSync(p, { recursive: true, force: true });
-  } catch (e) {
+    rmSync(p, { recursive: true, force: true });
+  } catch {
     // ignore errors
   }
-});
+}


### PR DESCRIPTION
## Summary
- convert `postinstall-cleanup.js` to pure ESM
- add runtime checks for Node version and module context

## Testing
- `node scripts/postinstall-cleanup.js`
- `node scripts/backfillMissingProjectIds.js` *(fails: Cannot find package '@neondatabase/serverless')*
- `node scripts/neonDb.js` *(fails: Cannot find package '@neondatabase/serverless')*
- `node scripts/recalculateTrustScores.js` *(fails: Cannot find package '@neondatabase/serverless')*
- `node scripts/processBrief.js` *(fails: Cannot find package 'pdf-parse')*
- `yarn install` *(fails: RequestError 403)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68712fe0b4b88327ae5160b8acaa890f