### PR TITLE
Remove favicon asset and document local icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ drizzle/*.db
 
 # Custom scripts/output
 scripts/output/
+
+# Favicon is generated locally
+public/favicon.ico

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ npm run dev
 yarn dev
 ```
 
+### Favicon
+
+The repository does not include `public/favicon.ico`. If you want to use a
+custom icon, create or download one and place it in `public/favicon.ico`. This
+file is ignored by Git so your personal icon won't be committed.
+
 When working in cloud IDEs such as StackBlitz or Codesandbox, you may see a `.next/` folder created after running the dev server. This directory contains build artifacts and is already listed in `.gitignore`, so it can safely be removed or ignored.
 
 ## Mock User Credentials

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 import { Toaster } from '@/components/ui/sonner';
 import '@/styles/globals.css';
@@ -8,9 +9,15 @@ import DevRoleSwitcher from '@/components/dev/DevRoleSwitcher';
 
 export const dynamic = 'force-dynamic';
 
-export const metadata = {
+export const metadata: Metadata = {
   title: 'Adhok',
   description: 'Next.js + Clerk App',
+  icons: [
+    {
+      rel: 'icon',
+      url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzAwIiBoZWlnaHQ9IjMwMCIgdmlld0JveD0iMCAwIDMwMCAzMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTE1MCAyNUwyNjIuNSA4Ny41VjIxMi41TDE1MCAyNzVMMzcuNSAyMTIuNVY4Ny41TDE1MCAyNVoiIGZpbGw9IiMwMEE0OTkiLz4KICA8cGF0aCBkPSJNMTUwIDc1TDEwMCAxMjVNMTUwIDc1TDIwMCAxMjVNMTUwIDc1VjE3NU0xMDAgMTI1VjE3NU0yMDAgMTI1VjE3NU0xMDAgMTc1TDE1MCAyMjVNMTUwIDE3NVYyMjVNMjAwIDE3NUwxNTAgMjI1IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIwIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KPC9zdmc+Cg=='
+    },
+  ],
 };
 
 export default function RootLayout({ children }: { children: any }) {


### PR DESCRIPTION
## Summary
- ignore local `public/favicon.ico`
- embed base64 favicon in the layout metadata
- document how to generate a favicon locally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: Cannot find type definition file for '@clerk/nextjs')*

------
https://chatgpt.com/codex/tasks/task_e_68713c0eb4f48327ba3795a49adcb056