### PR TITLE
Enforce type-only imports

### DIFF
--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -1,7 +1,7 @@
 'use client';
 import * as React from 'react';
 import * as RechartsPrimitive from 'recharts';
-import {
+import type {
   NameType,
   Payload,
   ValueType,

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -3,11 +3,13 @@ import * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';
 import {
   Controller,
+  FormProvider,
+  useFormContext,
+} from 'react-hook-form';
+import type {
   ControllerProps,
   FieldPath,
   FieldValues,
-  FormProvider,
-  useFormContext,
 } from 'react-hook-form';
 
 import { cn } from '@/lib/utils';

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -6,7 +6,8 @@ import {
 } from '@radix-ui/react-icons';
 
 import { cn } from '@/lib/utils';
-import { ButtonProps, buttonVariants } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button';
+import type { ButtonProps } from '@/components/ui/button';
 
 const Pagination = ({ className, ...props }: React.ComponentProps<'nav'>) => (
   <nav

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import parser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
 
 export default [
   { ignores: ['dist'] },
@@ -14,9 +15,11 @@ export default [
     },
     plugins: {
       'react-hooks': reactHooks,
+      '@typescript-eslint': tsPlugin,
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
 ];

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "drizzle-kit": "^0.21.2",
     "eslint": "^8.56.0",
     "eslint-config-next": "14.1.0",
+    "@typescript-eslint/eslint-plugin": "^6.22.0",
     "@types/lodash": "^4.14.202",
     "next": "^15.3.4",
     "postcss": "^8.4.35",

--- a/scripts/check-type-imports.cjs
+++ b/scripts/check-type-imports.cjs
@@ -16,6 +16,26 @@ if (metadataMisuse) {
   hasErrors = true;
 }
 
+const typePatterns = [
+  ['ControllerProps', 'react-hook-form'],
+  ['FieldPath', 'react-hook-form'],
+  ['FieldValues', 'react-hook-form'],
+  ['NameType', 'recharts/types/component/DefaultTooltipContent'],
+  ['Payload', 'recharts/types/component/DefaultTooltipContent'],
+  ['ValueType', 'recharts/types/component/DefaultTooltipContent'],
+  ['NextRequest', 'next/server'],
+  ['NextApiResponse', 'next'],
+  ['ButtonProps', '@/components/ui/button'],
+];
+
+for (const [name, mod] of typePatterns) {
+  const result = search(`import { ${name} } from '${mod}'`);
+  if (result) {
+    console.error(`${name} must be imported using \`import type\`:\n` + result);
+    hasErrors = true;
+  }
+}
+
 const legacyRequire = search('require(');
 if (legacyRequire) {
   console.error('Legacy require() usage detected:\n' + legacyRequire);


### PR DESCRIPTION
## Summary
- use `import type` for React Hook Form, Recharts and UI types
- enforce `consistent-type-imports` via ESLint
- check common framework types in `check-type-imports.cjs`
- add ESLint plugin dependency

## Testing
- `npm run type-check` *(fails: Cannot find type definition file for '@clerk/nextjs')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68714e0231288327bd56911e75906d35