### PR TITLE
Add package.json linting

### DIFF
--- a/.github/workflows/package-json.yml
+++ b/.github/workflows/package-json.yml
@@ -1,0 +1,13 @@
+name: Package JSON Lint
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: yarn install --check-files
+      - run: node scripts/lint-package-json.cjs

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "yarn check-supabase && yarn check-type-imports && yarn type-check",
+    "prebuild": "yarn install --check-files && yarn check-supabase && yarn check-type-imports && yarn type-check",
     "build": "next build",
     "check-supabase": "node scripts/check-no-supabase.cjs",
     "check-type-imports": "node scripts/check-type-imports.cjs",
     "type-check": "tsc --noEmit",
-    "lint": "eslint .",
+    "lint": "yarn lint:package && eslint .",
+    "lint:package": "node scripts/lint-package-json.cjs",
     "start": "next start",
     "db:push": "node --import dotenv/config node_modules/.bin/drizzle-kit push:pg",
     "db:generate": "node --import dotenv/config node_modules/.bin/drizzle-kit generate:pg",
@@ -25,12 +26,8 @@
     "postinstall": "node scripts/postinstall-cleanup.js",
     "preinstall": "node scripts/check-banned-packages.cjs",
     "check-lockfile": "node scripts/check-package-manager.cjs",
-
     "check-eslint-versions": "node scripts/check-eslint-versions.cjs",
     "verify": "yarn lint && yarn type-check && yarn check-lockfile && yarn check-eslint-versions"
-
-    "verify": "yarn lint && yarn type-check && yarn check-lockfile"
-
   },
   "dependencies": {
     "@clerk/nextjs": "^4.31.8",

--- a/scripts/lint-package-json.cjs
+++ b/scripts/lint-package-json.cjs
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const file = 'package.json';
+let src;
+try {
+  src = fs.readFileSync(file, 'utf8');
+} catch (err) {
+  console.error(`Failed to read ${file}`);
+  process.exit(1);
+}
+
+try {
+  execSync(`prettier --write ${file}`, { stdio: 'ignore' });
+} catch (err) {
+  console.error('Prettier formatting failed');
+  process.exit(1);
+}
+
+let pkg;
+try {
+  pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+} catch (err) {
+  console.error('package.json is not valid JSON');
+  process.exit(1);
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(msg);
+    process.exit(1);
+  }
+}
+
+assert(typeof pkg.name === 'string', 'package.json: name must be a string');
+assert(typeof pkg.version === 'string', 'package.json: version must be a string');
+if (pkg.dependencies) assert(typeof pkg.dependencies === 'object', 'dependencies must be an object');
+if (pkg.devDependencies) assert(typeof pkg.devDependencies === 'object', 'devDependencies must be an object');
+
+function checkDeps(obj, name) {
+  for (const [k, v] of Object.entries(obj || {})) {
+    if (!v) {
+      console.error(`${name} dependency ${k} has empty version`);
+      process.exit(1);
+    }
+  }
+}
+checkDeps(pkg.dependencies, '');
+checkDeps(pkg.devDependencies, 'dev');
+
+console.log('package.json lint passed');


### PR DESCRIPTION
## Summary
- check package.json formatting and schema via new script
- enforce package.json validity in CI
- call new lint in yarn scripts and prebuild

## Testing
- `node scripts/lint-package-json.cjs`
- `yarn type-check` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687158b1c2888327bf34fbfa6b2e318f