### PR TITLE
Fix type package duplication

### DIFF
--- a/.github/workflows/lock-integrity.yml
+++ b/.github/workflows/lock-integrity.yml
@@ -1,0 +1,14 @@
+name: Lockfile Integrity
+on: [push, pull_request]
+jobs:
+  dedupe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npx yarn-deduplicate
+      - run: yarn install --check-files
+      - run: node scripts/check-type-versions.cjs

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^8.57.1",
-    "@types/node": "^20.11.17",
-    "@types/pg": "^8.11.2",
+    "@types/node": "22.15.33",
+    "@types/pg": "8.11.6",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.17",
@@ -106,10 +106,5 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.8.3"
-  },
-  "resolutions": {
-    "@types/node": "20.17.50",
-    "@types/pg": "8.15.4",
-    "@clerk/types": "3.65.5"
   }
 }

--- a/scripts/check-type-versions.cjs
+++ b/scripts/check-type-versions.cjs
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const lock = fs.readFileSync('yarn.lock', 'utf8');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+
+function getMajors(name) {
+  const regex = new RegExp(`"${name}@[^"]*"\n  version \"([^\"]+)\"`, 'g');
+  const majors = new Set();
+  let m;
+  while ((m = regex.exec(lock))) {
+    majors.add(m[1].split('.')[0]);
+  }
+  return majors;
+}
+
+['@types/node', '@types/pg'].forEach(name => {
+  const majors = getMajors(name);
+  if (majors.size > 1) {
+    console.error(`Multiple major versions for ${name}: ${[...majors].join(', ')}`);
+    process.exit(1);
+  }
+});
+
+if (pkg.resolutions) {
+  for (const [name, version] of Object.entries(pkg.resolutions)) {
+    if (!name.startsWith('@types/')) continue;
+    const declared = pkg.dependencies?.[name] || pkg.devDependencies?.[name];
+    if (declared && !version.startsWith(declared.split('.')[0])) {
+      console.error(`Resolution ${name}@${version} conflicts with declared range ${declared}`);
+      process.exit(1);
+    }
+  }
+}
+
+console.log('type package versions consistent');

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,7 +20,7 @@
     "@clerk/shared" "1.4.2"
     "@clerk/types" "3.65.5"
     "@peculiar/webcrypto" "1.4.1"
-    "@types/node" "16.18.6"
+    "@types/node" "22.15.33"
     cookie "0.5.0"
     deepmerge "4.2.2"
     node-fetch-native "1.0.1"
@@ -1418,12 +1418,12 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^20.11.17", "@types/node@>= 12":
-  version "20.17.50"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz"
-  integrity sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==
+"@types/node@*", "@types/node@^20.11.17", "@types/node@>= 12", "@types/node@^22.7.5":
+  version "22.15.33"
+  resolved "https://registry.npmjs.org/@types/node/-/node-22.15.33.tgz"
+  integrity sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/node@^22.7.5":
   version "22.15.33"
@@ -1432,19 +1432,14 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/node@16.18.6":
-  version "16.18.6"
-  resolved "https://registry.npmjs.org/@types/node/-/node-16.18.6.tgz"
-  integrity sha512-vmYJF0REqDyyU0gviezF/KHq/fYaUbFhkcNbQCuPGFQj6VTbXuHZoxs/Y7mutWe73C8AC6l9fFu8mSYiBAqkGA==
-
 "@types/pg@*", "@types/pg@^8.11.2":
-  version "8.15.4"
-  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.15.4.tgz"
-  integrity sha512-I6UNVBAoYbvuWkkU3oosC8yxqH21f4/Jc4DK71JLG3dT2mdlGe1z+ep/LQGXaKaOgcvUrsQoPRqfgtMcvZiJhg==
+  version "8.11.6"
+  resolved "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz"
+  integrity sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==
   dependencies:
     "@types/node" "*"
     pg-protocol "*"
-    pg-types "^2.2.0"
+    pg-types "^4.0.1"
 
 "@types/pg@8.11.6":
   version "8.11.6"


### PR DESCRIPTION
## Summary
- dedupe @types dependencies by pinning to Node 22 and pg 8.11.6
- add workflow to enforce yarn-deduplicate and lock checks
- script to verify type package versions

## Testing
- `npx yarn-deduplicate` *(fails: 403 Forbidden)*
- `yarn install` *(fails: network access blocked)*
- `yarn type-check` *(fails: lockfile not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68715bed18308327a5569ae51e0e70bd