### PR TITLE
Ensure type import checks

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -12,4 +12,4 @@ Before committing, run the full verification suite:
 
 
 
-During CI and `prebuild` a custom script `check-type-imports` runs to ensure framework types such as `Metadata` and `NextRequest` are only imported using `import type` statements and that no legacy `require()` calls are present.
+During CI and `prebuild` a custom script `check-type-imports` runs to ensure framework types such as `Metadata`, `NextRequest` and `NextApiRequest` are only imported using `import type` statements and that no legacy `require()` calls are present.

--- a/scripts/check-type-imports.cjs
+++ b/scripts/check-type-imports.cjs
@@ -24,6 +24,7 @@ const typePatterns = [
   ['Payload', 'recharts/types/component/DefaultTooltipContent'],
   ['ValueType', 'recharts/types/component/DefaultTooltipContent'],
   ['NextRequest', 'next/server'],
+  ['NextApiRequest', 'next'],
   ['NextApiResponse', 'next'],
   ['ButtonProps', '@/components/ui/button'],
 ];

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- enforce type imports for NextApiRequest in check script
- align tsconfig.node.json with bundler settings
- document additional check in TESTING

## Testing
- `yarn type-check` *(fails: package missing from lockfile)*
- `yarn lint` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68715c7caeb88327ad052b62a69b91be