### PR TITLE
Fix build checks for Metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "backfill-missing-ids": "node --import dotenv/config scripts/backfillMissingProjectIds.js",
     "recalculate-trust-scores": "node --import dotenv/config scripts/recalculateTrustScores.js",
     "process-brief": "node scripts/processBrief.js",
-    "postinstall": "node scripts/postinstall-cleanup.js",
+    "postinstall": "node scripts/postinstall-cleanup.cjs",
     "preinstall": "node scripts/check-banned-packages.cjs",
     "check-lockfile": "node scripts/check-package-manager.cjs",
     "check-eslint-versions": "node scripts/check-eslint-versions.cjs",

--- a/scripts/check-type-imports.cjs
+++ b/scripts/check-type-imports.cjs
@@ -16,6 +16,12 @@ if (metadataMisuse) {
   hasErrors = true;
 }
 
+const metadataNamespace = search('Metadata\\.');
+if (metadataNamespace) {
+  console.error('Metadata must not be used as a namespace:\n' + metadataNamespace);
+  hasErrors = true;
+}
+
 const typePatterns = [
   ['ControllerProps', 'react-hook-form'],
   ['FieldPath', 'react-hook-form'],

--- a/scripts/postinstall-cleanup.cjs
+++ b/scripts/postinstall-cleanup.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { rmSync } from 'fs';
+const { rmSync } = require('fs');
 
 const MIN_NODE_MAJOR = 18;
 const currentMajor = parseInt(process.versions.node.split('.')[0], 10);


### PR DESCRIPTION
## Summary
- use CommonJS for `postinstall-cleanup` and rename to `.cjs`
- enforce that `Metadata` isn't used as a namespace in `check-type-imports`
- update `postinstall` script path

## Testing
- `node scripts/check-type-imports.cjs`
- `npx tsc --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_687169cd3df483278eba7669cada5044