### PR TITLE
Fix postinstall cleanup script

### DIFF
--- a/scripts/postinstall-cleanup.cjs
+++ b/scripts/postinstall-cleanup.cjs
@@ -10,11 +10,6 @@ if (currentMajor < MIN_NODE_MAJOR) {
   );
 }
 
-if (process.mainModule) {
-  console.warn(
-    '[postinstall-cleanup] Expected ESM context but running as CommonJS.'
-  );
-}
 
 const paths = [
   'node_modules/drizzle-orm/mysql-core',


### PR DESCRIPTION
## Summary
- silence postinstall cleanup by removing CommonJS warning

## Testing
- `yarn verify` *(fails: consistent-type-imports error)*

------
https://chatgpt.com/codex/tasks/task_e_68753722f4788327ac031421389a7bcf