### PR TITLE
Fix TESTING.md verify instructions

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -8,8 +8,10 @@ yarn type-check
 ```
 
 Before committing, run the full verification suite:
+```
+yarn verify
+```
 
-
-
+The `verify` script runs `yarn lint`, `yarn type-check`, `yarn check-lockfile` and `yarn check-eslint-versions`.
 
 During CI and `prebuild` a custom script `check-type-imports` runs to ensure framework types such as `Metadata`, `NextRequest` and `NextApiRequest` are only imported using `import type` statements and that no legacy `require()` calls are present.


### PR DESCRIPTION
## Summary
- restore instructions on how to run `yarn verify`
- describe checks included in the verify script

## Testing
- `yarn verify` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68753ea098c48327b041f666a05d8386