### PR TITLE
Add setup-mock-data script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:generate": "node --import dotenv/config node_modules/.bin/drizzle-kit generate:pg",
     "db:studio": "node --import dotenv/config node_modules/.bin/drizzle-kit studio",
     "seed-auth": "node --import dotenv/config scripts/seed-auth-users.js",
+    "setup-mock-data": "node scripts/setupMockData.js",
     "backfill-missing-ids": "node --import dotenv/config scripts/backfillMissingProjectIds.js",
     "recalculate-trust-scores": "node --import dotenv/config scripts/recalculateTrustScores.js",
     "process-brief": "node scripts/processBrief.js",

--- a/scripts/setupMockData.js
+++ b/scripts/setupMockData.js
@@ -1,0 +1,3 @@
+console.log('Setting up mock data...');
+// TODO: implement mock data seeding
+console.log('Mock data setup complete.');


### PR DESCRIPTION
## Summary
- add placeholder `setupMockData.js` script
- wire up `yarn setup-mock-data` in package.json

## Testing
- `yarn verify` *(fails: package doesn't seem to be present in the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68754208e0c08327b3f95412d69724f3