### PR TITLE
Fix preview mock mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ populate mock user details and refreshes the page when a new role is selected.
 
 Preview deployments (e.g. StackBlitz) can use mock authentication by setting
 `NEXT_PUBLIC_USE_MOCK=true` in the environment. This skips Clerk checks in
-`middleware.ts` and `useAuth.tsx`. If you encounter 401 errors or redirect loops
-when testing a preview, enable this variable to force mock mode.
+`middleware.ts` and tells `useAuth.tsx` to read the `dev_user_role` value from
+`localStorage` even when `NODE_ENV` is not `development`. If you encounter 401
+errors or redirect loops when testing a preview, enable this variable and select
+a role using the DevRoleSwitcher to force mock mode.
 
 ### Favicon
 
@@ -112,8 +114,9 @@ user role for testing. The selected role is saved to `localStorage` under the
 update the mock auth state.
 
 For preview environments such as StackBlitz, set
-`NEXT_PUBLIC_USE_MOCK=true` in your `.env` file. This bypasses Clerk and uses
-the mock role logic automatically.
+`NEXT_PUBLIC_USE_MOCK=true` in your `.env` file. This bypasses Clerk and tells
+`useAuth.tsx` to read `dev_user_role` even in production mode, so choose a role
+via the DevRoleSwitcher before testing.
 
 If you encounter `401` errors or an infinite reload loop, ensure that a role is
 stored in `dev_user_role` or clear the key and choose a role again.

--- a/app/talent/dashboard/page.tsx
+++ b/app/talent/dashboard/page.tsx
@@ -113,13 +113,13 @@ export default function TalentDashboard() {
     }
   }, [userId]);
 
-  const statLabelMap = {
+  const statLabelMap: Record<string, string> = {
     activeBids: "Active Bids",
     earnings: "Revenue Overview",
     portfolio: "Completed Projects",
   };
 
-  const statValueMap = {
+  const statValueMap: Record<string, string | number> = {
     activeBids: 1,
     earnings: "$7,200",
     portfolio: 1,
@@ -139,7 +139,7 @@ export default function TalentDashboard() {
     <div className="max-w-6xl mx-auto p-6">
       <div className="flex justify-between items-center mb-6 px-2 md:px-0">
         <h1 className="text-3xl font-bold text-[#2E3A8C]">Talent Dashboard</h1>
-        <BadgeDisplay />
+        <BadgeDisplay tier="Expert Talent" />
         <Button onClick={() => router.push(`/talent/${userId}/projects`)}>Browse Projects</Button>
       </div>
 

--- a/components/ActiveBidsPanel.tsx
+++ b/components/ActiveBidsPanel.tsx
@@ -1,8 +1,7 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+"use client";
+import { useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 
 interface Bid {
   id: string;
@@ -17,7 +16,7 @@ interface Project {
   title: string;
 }
 
-const USE_MOCK_DATA = true; // Set to false in production
+const USE_MOCK_DATA = true;
 
 export default function ActiveBidsPanel({ userId }: { userId: string }) {
   const [bids, setBids] = useState<Bid[]>([]);
@@ -26,38 +25,37 @@ export default function ActiveBidsPanel({ userId }: { userId: string }) {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch('/api/db?table=project_bids');
+        const res = await fetch("/api/db?table=project_bids");
         const json = await res.json();
         const userBids = (json.data || []).filter(
-          (b: any) => b.professionalId === userId
+          (b: any) => b.professionalId === userId,
         );
         setBids(userBids);
-
         const projectIds = userBids.map((b: any) => b.projectId);
         if (projectIds.length) {
-          const pres = await fetch('/api/db?table=projects');
+          const pres = await fetch("/api/db?table=projects");
           const pjson = await pres.json();
           setProjects(
-            (pjson.data || []).filter((p: any) => projectIds.includes(p.id))
+            (pjson.data || []).filter((p: any) => projectIds.includes(p.id)),
           );
         }
       } catch (err) {
-        console.error('Failed loading bids', err);
+        console.error("Failed loading bids", err);
       }
     }
 
     if (USE_MOCK_DATA) {
       setBids([
         {
-          id: 'bid1',
-          projectId: 'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14',
+          id: "bid1",
+          projectId: "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14",
           professionalId: userId,
           ratePerHour: 72,
-          status: 'active',
+          status: "active",
         },
       ]);
       setProjects([
-        { id: 'd0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14', title: 'Mock SEO Audit' },
+        { id: "d0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14", title: "Mock SEO Audit" },
       ]);
       return;
     }
@@ -67,19 +65,6 @@ export default function ActiveBidsPanel({ userId }: { userId: string }) {
 
   const getProjectTitle = (id: string) =>
     projects.find((p) => p.id === id)?.title || id;
-
-  const getStatusBadgeColor = (status?: string) => {
-    switch (status) {
-      case 'active':
-        return 'bg-green-100 text-green-800';
-      case 'pending':
-        return 'bg-yellow-100 text-yellow-800';
-      case 'rejected':
-        return 'bg-red-100 text-red-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
-    }
-  };
 
   if (!bids.length) {
     return (
@@ -96,3 +81,12 @@ export default function ActiveBidsPanel({ userId }: { userId: string }) {
           <CardContent className="p-4 flex justify-between items-center">
             <div>
               <h3 className="font-medium">{getProjectTitle(bid.projectId)}</h3>
+              <p className="text-sm text-gray-500">${bid.ratePerHour}/hr</p>
+            </div>
+            <Badge variant="secondary">{bid.status || "pending"}</Badge>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/components/BudgetTracker.tsx
+++ b/components/BudgetTracker.tsx
@@ -1,64 +1,14 @@
+'use client';
+interface Props {
+  projects: { projectBudget: number }[];
+}
 
-"use client";
-import { useEffect, useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Progress } from "@/components/ui/progress";
-
-const USE_MOCK_DATA = true;
-const MOCK_PROJECTS = [
-  {
-    id: "1",
-    clientId: "mock-client",
-    projectBudget: 3500,
-    amountSpent: 1200,
-  },
-  {
-    id: "2",
-    clientId: "mock-client",
-    projectBudget: 2800,
-    amountSpent: 800,
-  },
-];
-
-export default function BudgetTracker({ userId }: { userId: string }) {
-  const [projects, setProjects] = useState<any[]>([]);
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const res = await fetch("/api/db?table=projects");
-        const json = await res.json();
-        if (res.ok) {
-          const data = json.data || [];
-          setProjects(data.filter((p: any) => p.clientId === userId));
-        }
-      } catch (err) {
-        console.error("Error loading projects", err);
-      }
-    }
-    if (USE_MOCK_DATA) {
-      setProjects(MOCK_PROJECTS);
-      return;
-    }
-    if (userId) load();
-  }, [userId]);
-
+export default function BudgetTracker({ projects }: Props) {
   const total = projects.reduce((sum, p) => sum + (p.projectBudget || 0), 0);
-  const spent = projects.reduce((sum, p) => sum + (p.amountSpent || 0), 0);
-  const percent = total ? Math.round((spent / total) * 100) : 0;
-
-  if (!projects.length) return null;
-
   return (
-    <Card>
-      <CardContent className="p-4 space-y-2">
-        <h3 className="font-semibold">Budget Tracker</h3>
-        <div className="text-sm text-gray-600">
-          Spent ${spent.toLocaleString()} of ${total.toLocaleString()}
-        </div>
-        <Progress value={percent} />
-      </CardContent>
-    </Card>
+    <div className="p-4 bg-gray-50 border rounded mb-4 text-sm">
+      <span className="font-semibold">Total Budget:</span> ${total.toLocaleString()}
+    </div>
   );
 }
 

--- a/components/ClientProjectsList.tsx
+++ b/components/ClientProjectsList.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import { useRouter } from 'next/navigation';
 import { Briefcase, CheckCircle, Clock, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -22,7 +21,6 @@ export default function ClientProjectsList({ projects }: Props) {
   const router = useRouter();
 
   const formatDate = (iso: string) => new Date(iso).toLocaleDateString();
-
   const getProjectUrl = (project: ClientProject) => {
     const workspacePhases = ['picked_up', 'submitted', 'revisions', 'approved', 'completed'];
     return workspacePhases.includes(project.status)
@@ -45,7 +43,7 @@ export default function ClientProjectsList({ projects }: Props) {
       approved: 'Approved',
       completed: 'Completed',
     };
-    return statusMap[status] || status;
+    return statusMap[status as keyof typeof statusMap] || status;
   };
 
   const getStatusIcon = (status: string) => {
@@ -61,7 +59,7 @@ export default function ClientProjectsList({ projects }: Props) {
     }
   };
 
-  if (!projects.length) {
+  if (projects.length === 0) {
     return (
       <div className="text-center py-12">
         <p className="text-gray-500 mb-4">No projects yet. Create your first project to get started!</p>
@@ -73,7 +71,35 @@ export default function ClientProjectsList({ projects }: Props) {
   }
 
   return (
-    <div className="grid gap-4">
+    <>
       {projects.map((proj) => (
         <div key={proj.id} className="border rounded-lg p-4 shadow-sm">
-          <div className="flex
+          <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+            <div className="flex-1 min-w-0">
+              <h2 className="text-lg font-semibold truncate">{proj.title}</h2>
+              <p className="text-sm text-gray-500">Deadline: {formatDate(proj.deadline)}</p>
+              <p className="text-sm text-gray-500">Budget: ${proj.projectBudget?.toLocaleString()}</p>
+            </div>
+            <Button
+              onClick={() => router.push(getProjectUrl(proj))}
+              className="w-full sm:w-auto bg-[#2E3A8C] text-white hover:bg-[#2E3A8C]/90"
+            >
+              {getButtonText(proj.status)}
+            </Button>
+          </div>
+
+          <div className="mt-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 text-sm text-gray-600">
+            <div className="flex items-center gap-1">
+              <Briefcase className="w-4 h-4" /> {proj.bids || 0} Bids
+            </div>
+            <div className="flex items-center gap-1">
+              {getStatusIcon(proj.status)}
+              {getStatusDisplay(proj.status)}
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+

--- a/lib/useAuth.tsx
+++ b/lib/useAuth.tsx
@@ -34,9 +34,10 @@ export const useAuth = () => useContext(AuthContext);
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const { user, isSignedIn, isLoaded } = useUser();
   const [state, setState] = useState(defaultAuthState);
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development' || isMock) {
       const devRole = localStorage.getItem('dev_user_role') as UserRole | null;
 
       if (devRole) {


### PR DESCRIPTION
## Summary
- update `useAuth.tsx` to enable mock mode outside development
- document mock auth environment variable in `README.md`
- fix badge prop usage and typed maps in `app/talent/dashboard/page.tsx`
- restore client components from previous revision

## Testing
- `yarn verify` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687936dac7e88327831d24ff1493db39