### PR TITLE
Fix mock mode fallback for Clerk provider

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,10 +37,12 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 
-  return isMock ? App : (
+  return isMock || !process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ? (
+    App
+  ) : (
     <ClerkProvider
-      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
-      frontendApi={process.env.NEXT_PUBLIC_CLERK_FRONTEND_API}
+      publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY!}
+      frontendApi={process.env.NEXT_PUBLIC_CLERK_FRONTEND_API!}
     >
       {App}
     </ClerkProvider>


### PR DESCRIPTION
## Summary
- prevent layout from using ClerkProvider when mock mode is enabled or missing env keys

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_6879593651c8832791d3a75ed0ecdfd0