### PR TITLE
Fix missing use client directives

### DIFF
--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from '@radix-ui/react-icons';

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 

--- a/components/ui/aspect-ratio.tsx
+++ b/components/ui/aspect-ratio.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as AspectRatioPrimitive from '@radix-ui/react-aspect-ratio';
 
 const AspectRatio = AspectRatioPrimitive.Root;

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as AvatarPrimitive from '@radix-ui/react-avatar';
 

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { cva } from 'class-variance-authority';
 

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { ChevronRightIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
 import { Slot } from '@radix-ui/react-slot';

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from '@radix-ui/react-icons';
 import { DayPicker } from 'react-day-picker';

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { CheckIcon } from '@radix-ui/react-icons';

--- a/components/ui/collapsible.tsx
+++ b/components/ui/collapsible.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as CollapsiblePrimitive from '@radix-ui/react-collapsible';
 
 const Collapsible = CollapsiblePrimitive.Root;

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { type DialogProps } from '@radix-ui/react-dialog';
 import { MagnifyingGlassIcon } from '@radix-ui/react-icons';

--- a/components/ui/context-menu.tsx
+++ b/components/ui/context-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import {

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"

--- a/components/ui/drawer.tsx
+++ b/components/ui/drawer.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Drawer as DrawerPrimitive } from 'vaul';
 

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import {

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import type * as LabelPrimitive from '@radix-ui/react-label';
 import { Slot } from '@radix-ui/react-slot';

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as HoverCardPrimitive from '@radix-ui/react-hover-card';
 

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { DashIcon } from '@radix-ui/react-icons';
 import { OTPInput, OTPInputContext } from 'input-otp';

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/components/ui/menubar.tsx
+++ b/components/ui/menubar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import {
   CheckIcon,

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { ChevronDownIcon } from '@radix-ui/react-icons';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import {
   ChevronLeftIcon,

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as PopoverPrimitive from '@radix-ui/react-popover';
 

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ProgressPrimitive from '@radix-ui/react-progress';
 

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { CheckIcon } from '@radix-ui/react-icons';
 import * as RadioGroupPrimitive from '@radix-ui/react-radio-group';

--- a/components/ui/resizable.tsx
+++ b/components/ui/resizable.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { DragHandleDots2Icon } from '@radix-ui/react-icons';
 import * as ResizablePrimitive from 'react-resizable-panels';
 

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,3 +1,4 @@
+'use client';
 
 import * as React from 'react';
 import { ChevronDownSquare, Check, ChevronDown, ChevronUp } from 'lucide-react';

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
 import { Cross2Icon } from '@radix-ui/react-icons';

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { cn } from '@/lib/utils';
 
 function Skeleton({

--- a/components/ui/slider.tsx
+++ b/components/ui/slider.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+'use client';
 
 import * as React from 'react';
 import { Toaster as SonnerToaster } from 'sonner';

--- a/components/ui/switch.tsx
+++ b/components/ui/switch.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
 

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 import { cn } from '@/lib/utils';

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import { Cross2Icon } from '@radix-ui/react-icons';
 import * as ToastPrimitives from '@radix-ui/react-toast';

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useToast } from '@/hooks/use-toast';
 import {
   Toast,

--- a/components/ui/toggle-group.tsx
+++ b/components/ui/toggle-group.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group';
 import { type VariantProps } from 'class-variance-authority';

--- a/components/ui/toggle.tsx
+++ b/components/ui/toggle.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as TogglePrimitive from '@radix-ui/react-toggle';
 import { cva, type VariantProps } from 'class-variance-authority';

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 


### PR DESCRIPTION
## Summary
- mark all UI components as client components

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_6879750c17788327a7c9ede07c288157