### PR TITLE
Add estimated-hours badge

### DIFF
--- a/components/DurationBadge.tsx
+++ b/components/DurationBadge.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface DurationBadgeProps {
+  estimatedHours?: number | null;
+  className?: string;
+}
+
+export default function DurationBadge({ estimatedHours, className }: DurationBadgeProps) {
+  if (estimatedHours === null || estimatedHours === undefined || isNaN(estimatedHours)) {
+    return null;
+  }
+
+  let label = 'Adhok';
+  let color = 'bg-blue-200 text-blue-800';
+
+  if (estimatedHours >= 60) {
+    label = 'Long-Term';
+    color = 'bg-red-200 text-red-800';
+  } else if (estimatedHours >= 30) {
+    label = 'Mid-Term';
+    color = 'bg-yellow-200 text-yellow-800';
+  } else if (estimatedHours >= 10) {
+    label = 'Short-Term';
+    color = 'bg-green-200 text-green-800';
+  }
+
+  return (
+    <Badge variant="secondary" className={cn('px-2 py-1 text-xs', color, className)}>
+      {label}
+    </Badge>
+  );
+}

--- a/components/ProjectDetailCard.tsx
+++ b/components/ProjectDetailCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { CalendarIcon } from 'lucide-react';
+import DurationBadge from '@/components/DurationBadge';
 
 interface Props {
   project: {
@@ -20,6 +21,7 @@ export default function ProjectDetailCard({ project }: Props) {
       <div className="flex items-center gap-2 text-sm text-gray-600">
         <CalendarIcon className="w-4 h-4" />
         <span>Deadline: {new Date(project.deadline).toLocaleDateString()}</span>
+        <DurationBadge estimatedHours={project.estimated_hours} />
       </div>
       <div className="text-sm text-gray-600">
         {project.estimated_hours}h @ ${project.hourly_rate}/hr

--- a/components/ProjectList.tsx
+++ b/components/ProjectList.tsx
@@ -1,6 +1,8 @@
 'use client';
 import React, { useState, useMemo } from 'react';
 import { Badge } from '@/components/ui/badge';
+import DurationBadge from '@/components/DurationBadge';
+import { calculateEstimatedHours } from '@/lib/estimation';
 import { Button } from '@/components/ui/button';
 import { Clock } from 'lucide-react';
 import { formatDistanceToNow, format } from 'date-fns';
@@ -13,6 +15,7 @@ interface Project {
   deadline: string;
   expertiseLevel: string;
   bidCount?: number;
+  projectBudget?: number;
   status?: string;
   overview?: string;
   deliverables?: string;
@@ -55,6 +58,7 @@ export default function ProjectList() {
       deadline: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString(),
       expertiseLevel: 'Mid-Level',
       bidCount: 30,
+      projectBudget: 1500,
       status: 'open',
       overview: 'Help an e-comm brand rank for new seasonal collections.',
       deliverables: '3-5 keyword-optimized landing pages',
@@ -71,6 +75,7 @@ export default function ProjectList() {
       deadline: new Date(Date.now() + 21 * 24 * 60 * 60 * 1000).toISOString(),
       expertiseLevel: 'Expert',
       bidCount: 75,
+      projectBudget: 5000,
       status: 'open',
       overview: 'Create a viral playbook for product launch.',
       deliverables: '15 content ideas, 7 draft captions, 1 calendar',
@@ -87,6 +92,7 @@ export default function ProjectList() {
       deadline: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
       expertiseLevel: 'Entry Level',
       bidCount: 15,
+      projectBudget: 800,
       status: 'open',
       overview: 'Support organic visibility by establishing topic clusters.',
       deliverables: '1 blog strategy, 10 topic outlines',
@@ -158,6 +164,14 @@ export default function ProjectList() {
                 Last bid: ${startingBidsByExpertise[formatExpertise(project.expertiseLevel)]}/hr
               </span>{' '}
               · <span>{timeRemaining(project.deadline)}</span>
+              <DurationBadge
+                className="ml-2"
+                estimatedHours={calculateEstimatedHours({
+                  budget: project.projectBudget,
+                  expertiseLevel: formatExpertise(project.expertiseLevel),
+                  title: project.title,
+                }) || undefined}
+              />
             </div>
           </div>
         ))}
@@ -242,6 +256,13 @@ export default function ProjectList() {
               <span className="ml-auto font-medium text-gray-800">
                 Ends in {timeRemaining(selectedProject.deadline)}
               </span>
+              <DurationBadge
+                estimatedHours={calculateEstimatedHours({
+                  budget: selectedProject.projectBudget,
+                  expertiseLevel: formatExpertise(selectedProject.expertiseLevel),
+                  title: selectedProject.title,
+                }) || undefined}
+              />
             </div>
             <div className="flex gap-4 items-center mb-4">
               <span className="text-sm text-gray-700 mr-2">

--- a/components/ProjectUploadFlow.tsx
+++ b/components/ProjectUploadFlow.tsx
@@ -8,12 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from 'sonner';
 import { Package } from 'lucide-react';
-
-const expertiseRates: { [key: string]: number } = {
-  'Specialist': 50,
-  'Pro Talent': 100,
-  'Expert Talent': 150,
-};
+import { calculateEstimatedHours, expertiseRates } from '@/lib/estimation';
 
 const projectPresets: { [key: string]: Array<{ title: string; description: string; deliverables: string; expertiseLevel: string }> } = {
   SEO: [
@@ -68,25 +63,12 @@ export function ProjectUploadFlow() {
     brandVoice: '',
   });
 
-  const getEstimatedHours = () => {
-    const rate = expertiseRates[form.expertiseLevel];
-    const budget = parseFloat(form.budget);
-    if (!rate || isNaN(budget)) return null;
-
-    const estimatedHoursMap: Record<string, number> = {
-      'Technical SEO Audit': 8,
-      'Full SEO Strategy Plan': 16,
-      'On-page Optimization for Blog': 6,
-      'Google Ads Audit': 10,
-    };
-
-    const matchKey = Object.keys(estimatedHoursMap).find((key) =>
-      form.title.toLowerCase().includes(key.toLowerCase().split(' ')[0])
-    );
-
-    if (matchKey) return estimatedHoursMap[matchKey];
-    return Math.floor(budget / rate);
-  };
+  const getEstimatedHours = () =>
+    calculateEstimatedHours({
+      budget: parseFloat(form.budget),
+      expertiseLevel: form.expertiseLevel,
+      title: form.title,
+    });
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     if (e.target.files?.length) {

--- a/lib/estimation.ts
+++ b/lib/estimation.ts
@@ -1,0 +1,34 @@
+export const expertiseRates: Record<string, number> = {
+  Specialist: 50,
+  'Pro Talent': 100,
+  'Expert Talent': 150,
+};
+
+const estimatedHoursMap: Record<string, number> = {
+  'Technical SEO Audit': 8,
+  'Full SEO Strategy Plan': 16,
+  'On-page Optimization for Blog': 6,
+  'Google Ads Audit': 10,
+};
+
+export function calculateEstimatedHours({
+  budget,
+  expertiseLevel,
+  title,
+}: {
+  budget?: number;
+  expertiseLevel?: string;
+  title?: string;
+}): number | null {
+  const rate = expertiseRates[expertiseLevel ?? ''];
+  if (!rate || typeof budget !== 'number' || isNaN(budget)) return null;
+
+  if (title) {
+    const matchKey = Object.keys(estimatedHoursMap).find((key) =>
+      title.toLowerCase().includes(key.toLowerCase().split(' ')[0])
+    );
+    if (matchKey) return estimatedHoursMap[matchKey];
+  }
+
+  return Math.floor(budget / rate);
+}


### PR DESCRIPTION
## Summary
- centralize estimated-hours calculation logic in `lib/estimation.ts`
- show duration tiers with new `DurationBadge` component
- use the utility in `ProjectUploadFlow` and project listing
- display hours badge on project cards and detail page

## Testing
- `yarn verify` *(fails: Error: package-lock.json found)*

------
https://chatgpt.com/codex/tasks/task_e_687baa0c7ca083279cca954490a614ae