### PR TITLE
Refactor pages to use unified auth hook

### DIFF
--- a/app/admin/projects/details/[id]/page.tsx
+++ b/app/admin/projects/details/[id]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import { toast } from 'sonner';
 import { 
   BadgeCheck, CalendarIcon, Clock, FileText, Link as LinkIcon, Target, Users, 
@@ -23,8 +23,14 @@ export default function AdminProjectDetail() {
   const [talent, setTalent] = useState<any>(null);
   const [reviews, setReviews] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const { user } = useUser();
-  const userRole = user?.publicMetadata?.role;
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+    isAuthenticated,
+  } = useAuth();
 
   useEffect(() => {
     const fetchProjectData = async () => {

--- a/app/admin/projects/details/page.tsx
+++ b/app/admin/projects/details/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import { toast } from 'sonner';
 import { 
   BadgeCheck, CalendarIcon, Clock, FileText, Link as LinkIcon, Target, Users, 
@@ -23,8 +23,14 @@ export default function AdminProjectDetail() {
   const [talent, setTalent] = useState<any>(null);
   const [reviews, setReviews] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
-  const { user } = useUser();
-  const userRole = user?.publicMetadata?.role;
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+    isAuthenticated,
+  } = useAuth();
 
   useEffect(() => {
     const fetchProjectData = async () => {

--- a/app/admin/talent/details/[id]/page.tsx
+++ b/app/admin/talent/details/[id]/page.tsx
@@ -8,7 +8,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { AlertTriangle, CheckCircle, Flag, RefreshCw, User, Mail, MapPin, Briefcase, Link as LinkIcon } from 'lucide-react';
 import { toast } from 'sonner';
 import TrustScoreCard from '@/components/admin/TrustScoreCard';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import QualificationHistoryTimeline, { type QualificationEntry } from '@/components/QualificationHistoryTimeline';
 
 interface TalentProfile {
@@ -58,17 +58,24 @@ export default function AdminTalentDetails() {
   const params = useParams();
   const router = useRouter();
   const id = params.id as string;
-  const { user, isSignedIn, isLoaded } = useUser();
-  const isAdmin = user?.publicMetadata?.role === 'admin';
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+    isAuthenticated,
+  } = useAuth();
+  const isAdmin = userRole === 'admin';
   const [talent, setTalent] = useState<TalentProfile | null>(null);
   const [loading, setLoading] = useState(true);
   const [updatingTrustScore, setUpdatingTrustScore] = useState(false);
 
   useEffect(() => {
-    if (isLoaded && isSignedIn && isAdmin && id) {
+    if (!authLoading && isAuthenticated && isAdmin && id) {
       fetchTalentDetails();
     }
-  }, [isLoaded, isSignedIn, isAdmin, id]);
+  }, [authLoading, isAuthenticated, isAdmin, id]);
 
   const fetchTalentDetails = async () => {
     try {
@@ -188,7 +195,7 @@ export default function AdminTalentDetails() {
     }
   };
 
-  if (!isLoaded) {
+  if (authLoading) {
     return (
       <div className="max-w-4xl mx-auto p-6 text-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#2E3A8C] mx-auto mb-4"></div>
@@ -197,7 +204,7 @@ export default function AdminTalentDetails() {
     );
   }
 
-  if (!isSignedIn || !isAdmin) {
+  if (!isAuthenticated || !isAdmin) {
     return (
       <div className="max-w-4xl mx-auto p-6 text-center">
         <p className="text-red-600">Unauthorized access. Admin privileges required.</p>

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import { useRouter } from 'next/navigation';
 
 import ClientProjectsList from '@/components/ClientProjectsList';
@@ -27,13 +27,20 @@ export default function ClientDashboard() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
-  const { user, isSignedIn, isLoaded } = useUser();
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+    isAuthenticated,
+  } = useAuth();
 
   useEffect(() => {
-    if (isLoaded && isSignedIn && user) {
+    if (!authLoading && isAuthenticated && userId) {
       fetchProjects();
     }
-  }, [isLoaded, isSignedIn, user]);
+  }, [authLoading, isAuthenticated, userId]);
 
   const fetchProjects = async () => {
     try {
@@ -62,7 +69,7 @@ export default function ClientDashboard() {
       } else {
         const res = await fetch('/api/db?table=projects');
         const json = await res.json();
-        const userProjects = (json.data || []).filter((p: any) => p.clientId === user?.id);
+        const userProjects = (json.data || []).filter((p: any) => p.clientId === userId);
         setProjects(userProjects);
       }
 
@@ -89,7 +96,7 @@ export default function ClientDashboard() {
     );
   }
 
-  if (!isSignedIn) {
+  if (!isAuthenticated) {
     return (
       <div className="max-w-5xl mx-auto p-4 sm:p-6 text-center">
         <p className="text-gray-600">Please sign in to view your dashboard.</p>

--- a/app/client/projects/details/[project_id]/page.tsx
+++ b/app/client/projects/details/[project_id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import { toast } from 'sonner';
 import {
   BadgeCheck,
@@ -28,7 +28,13 @@ export default function ClientProjectDetail() {
   const [talentProfile, setTalentProfile] = useState<any>(null);
   const [approving, setApproving] = useState(false);
   const [reviewing, setReviewing] = useState(false);
-  const { user, isLoaded } = useUser();
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+  } = useAuth();
 
   useEffect(() => {
     const fetchProject = async () => {
@@ -52,7 +58,7 @@ export default function ClientProjectDetail() {
     if (project_id) fetchProject();
   }, [project_id]);
 
-  if (!isLoaded) return <p className="p-6 text-center text-gray-600">Loading...</p>;
+  if (authLoading) return <p className="p-6 text-center text-gray-600">Loading...</p>;
   if (!project) return <p className="p-6 text-center text-gray-600">Loading project details...</p>;
 
   const totalBudget = project.estimated_hours * project.hourly_rate;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,6 @@ export const metadata = {
   icons: [{ rel: 'icon', url: '/favicon.svg' }],
 };
 
-const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
 const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API;
 
@@ -31,11 +30,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body suppressHydrationWarning={true}>
-        {isMock || !clerkKey ? inner : (
-          <ClerkProvider publishableKey={clerkKey!} frontendApi={clerkApi!}>
-            {inner}
-          </ClerkProvider>
-        )}
+        <ClerkProvider publishableKey={clerkKey} frontendApi={clerkApi}>
+          {inner}
+        </ClerkProvider>
       </body>
     </html>
   );

--- a/app/sign-in-callback/page.tsx
+++ b/app/sign-in-callback/page.tsx
@@ -1,21 +1,28 @@
 'use client';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 
 export default function SignInCallback() {
-  const { user, isLoaded, isSignedIn } = useUser();
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading,
+    isAuthenticated,
+  } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!isLoaded) return;
+    if (loading) return;
 
-    if (!isSignedIn) {
+    if (!isAuthenticated) {
       router.replace('/sign-in');
       return;
     }
 
-    const role = user?.publicMetadata?.role as string | undefined;
+    const role = userRole as string | undefined;
     let destination = '/waitlist';
 
     if (role === 'admin') destination = '/admin/panel';
@@ -23,7 +30,7 @@ export default function SignInCallback() {
     else if (role === 'talent') destination = '/talent/dashboard';
 
     router.replace(destination);
-  }, [isLoaded, isSignedIn, user, router]);
+  }, [loading, isAuthenticated, userRole, router]);
 
   return (
     <main className="min-h-screen flex items-center justify-center">

--- a/app/talent/projects/workspace/[project_id]/page.tsx
+++ b/app/talent/projects/workspace/[project_id]/page.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
-import { useUser } from '@clerk/nextjs';
+import { useAuth } from '@/lib/useAuth';
 import { CalendarIcon, Clock, ExternalLink, AlertTriangle, MessageSquare, CreditCard } from 'lucide-react';
 import { format, formatDistanceToNow } from 'date-fns';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -108,7 +108,14 @@ export default function ProjectWorkspace() {
   const router = useRouter();
   const pathname = usePathname();
   const project_id = params.project_id as string;
-  const { user } = useUser();
+  const {
+    userId,
+    userRole,
+    username,
+    authUser,
+    loading: authLoading,
+    isAuthenticated,
+  } = useAuth();
   const [projectName] = useState("SEO Optimization");
   const [projectDeadline] = useState(new Date(Date.now() + 14 * 24 * 60 * 60 * 1000));
   const [projectStartDate] = useState(new Date());
@@ -158,7 +165,6 @@ export default function ProjectWorkspace() {
   }
 
   if (!canAccess) {
-    const username = user?.username || user?.id;
     return (
       <div className="min-h-screen bg-[#F0F4FF] flex items-center justify-center p-4">
         <div className="max-w-md mx-auto text-center">
@@ -182,7 +188,6 @@ export default function ProjectWorkspace() {
 
   const progress = getApprovalProgress();
   const isPickedUp = projectStatus === 'Picked Up';
-  const username = user?.username || user?.id;
 
   return (
     <div className="min-h-screen bg-[#F0F4FF]">


### PR DESCRIPTION
## Summary
- wrap app with ClerkProvider in layout to avoid missing user context
- switch all pages from `useUser` to `useAuth`
- standardize auth checks on client and admin dashboards
- update sign-in callback logic for unified auth handling
- adjust talent workspace to consume new auth state

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687be24831d48327914bb792136d4a64