### PR TITLE
Enable mock project context

### DIFF
--- a/app/admin/panel/page.tsx
+++ b/app/admin/panel/page.tsx
@@ -3,14 +3,21 @@ import AdminClientList from '@/components/AdminClientList';
 import AdminTalentList from '@/components/AdminTalentList';
 import AdminLineChart from '@/components/AdminLineChart';
 import ReviewList from '@/components/ReviewList';
+import AdminProjectList from '@/components/AdminProjectList';
+import { useMockData } from '@/lib/useMockData';
 import { useEffect, useState } from 'react';
 
 export default function AdminPanel() {
+  const { reviews: mockReviews } = useMockData();
   const [reviews, setReviews] = useState<any[]>([]);
 
   useEffect(() => {
     async function loadReviews() {
       try {
+        if (process.env.NEXT_PUBLIC_USE_MOCK === 'true') {
+          setReviews(mockReviews);
+          return;
+        }
         const res = await fetch('/api/db?table=project_reviews');
         const json = await res.json();
         if (res.ok) setReviews(json.data || []);
@@ -24,6 +31,7 @@ export default function AdminPanel() {
   return (
     <div className="max-w-6xl mx-auto p-6 space-y-8">
       <AdminLineChart selectedMetrics={['totalProjects','estRevenue','activeTalent']} />
+      <AdminProjectList />
       <AdminClientList />
       <AdminTalentList />
       <ReviewList reviews={reviews} />

--- a/app/api/admin/projects/route.ts
+++ b/app/api/admin/projects/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { projects } from '@/lib/schema';
 import { auth } from '@clerk/nextjs/server';
+import { mockProjects } from '@/lib/mockData';
 
 type SessionClaimsWithRole = {
   metadata?: {
@@ -11,6 +12,11 @@ type SessionClaimsWithRole = {
 };
 
 export async function GET(_req: NextRequest) {
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+  if (isMock) {
+    return NextResponse.json({ data: mockProjects });
+  }
+
   const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -5,8 +5,14 @@ import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm/pg-core';
 import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
+import { mockClients } from '@/lib/mockData';
 
 export async function GET(_req: NextRequest) {
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+  if (isMock) {
+    return NextResponse.json({ data: mockClients });
+  }
+
   const { userId, sessionClaims } = await auth();
   const role = (sessionClaims as SessionClaimsWithRole)?.metadata?.role;
 

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -11,7 +11,7 @@ import BudgetTracker from '@/components/BudgetTracker';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { Plus } from 'lucide-react';
-import { mockProjects, mockClient } from '@/lib/mockData';
+import { useMockData } from '@/lib/useMockData';
 
 interface Project {
   id: string;
@@ -24,6 +24,7 @@ interface Project {
 
 
 export default function ClientDashboard() {
+  const { projects: allProjects, clients } = useMockData();
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
@@ -46,7 +47,8 @@ export default function ClientDashboard() {
     try {
       setLoading(true);
 
-      const userProjects = mockProjects.filter(p => p.client.id === mockClient.id);
+      const me = clients.find(c => c.id === userId) || clients[0];
+      const userProjects = allProjects.filter(p => p.client.id === me.id);
       setProjects(userProjects as unknown as Project[]);
 
     } catch (error) {

--- a/app/client/projects/details/[project_id]/page.tsx
+++ b/app/client/projects/details/[project_id]/page.tsx
@@ -20,7 +20,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import ProjectStatusCard from '@/components/ProjectStatusCard';
 import TalentAssignmentBox from '@/components/TalentAssignmentBox';
-import { getProjectById } from '@/lib/mockData';
+import { useMockData } from '@/lib/useMockData';
 
 export default function ClientProjectDetail() {
   const params = useParams();
@@ -37,6 +37,8 @@ export default function ClientProjectDetail() {
     loading: authLoading,
   } = useAuth();
 
+  const { getProjectById } = useMockData();
+
   useEffect(() => {
     if (project_id) {
       const proj = getProjectById(project_id);
@@ -45,7 +47,7 @@ export default function ClientProjectDetail() {
         if (proj.talent) setTalentProfile(proj.talent);
       }
     }
-  }, [project_id]);
+  }, [project_id, getProjectById]);
 
   if (authLoading) return <p className="p-6 text-center text-gray-600">Loading...</p>;
   if (!project) return <p className="p-6 text-center text-gray-600">Loading project details...</p>;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ClerkProvider } from '@clerk/nextjs';
 import { Toaster } from '@/components/ui/sonner';
 import { Header } from '@/components/Header';
 import { AuthProvider } from '@/lib/useAuth';
+import { MockDataProvider } from '@/lib/useMockData';
 import DevRoleSwitcher from '@/components/dev/DevRoleSwitcher';
 
 export const dynamic = 'force-dynamic';
@@ -19,12 +20,14 @@ const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   const inner = (
-    <AuthProvider>
-      <Header />
-      {children}
-      <Toaster />
-      <DevRoleSwitcher />
-    </AuthProvider>
+    <MockDataProvider>
+      <AuthProvider>
+        <Header />
+        {children}
+        <Toaster />
+        <DevRoleSwitcher />
+      </AuthProvider>
+    </MockDataProvider>
   );
 
   return (

--- a/app/talent/dashboard/page.tsx
+++ b/app/talent/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { toast } from "sonner";
 import { useAuth } from "@/lib/useAuth";
-import { mockProjects, mockTalent } from "@/lib/mockData";
+import { useMockData } from "@/lib/useMockData";
 import {
   Clock,
   ArrowRight,
@@ -95,6 +95,7 @@ interface Project {
 
 export default function TalentDashboard() {
   const { userId } = useAuth();
+  const { projects: allProjects, talents } = useMockData();
   const router = useRouter();
 
   const [currentTab, setCurrentTab] = useState<'activeBids' | 'earnings' | 'portfolio' | 'won'>('activeBids');
@@ -104,17 +105,19 @@ export default function TalentDashboard() {
 
   useEffect(() => {
     if (userId) {
-      const assigned = mockProjects.filter(p => p.talent?.id === userId);
+      const assigned = allProjects.filter(p => p.talent?.id === userId);
       setProjects(assigned as unknown as Project[]);
-      setProfile({
-        fullName: mockTalent.fullName,
-        username: mockTalent.username,
-        email: mockTalent.email,
-        expertise: mockTalent.expertise,
-        experienceBadge: mockTalent.badge,
-      });
+      const t = talents.find(t => t.id === userId) || talents[0];
+      if (t)
+        setProfile({
+          fullName: t.fullName,
+          username: t.username,
+          email: t.email,
+          expertise: t.expertise,
+          experienceBadge: t.badge,
+        });
     }
-  }, [userId]);
+  }, [userId, allProjects, talents]);
 
   const statLabelMap: Record<string, string> = {
     activeBids: "Active Bids",

--- a/app/talent/projects/details/[project_id]/page.tsx
+++ b/app/talent/projects/details/[project_id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import ProjectDetailCard from '@/components/ProjectDetailCard';
 import SubmitWorkButton from '@/components/SubmitWorkButton';
 import LeaveReviewButton from '@/components/LeaveReviewButton';
+import { useMockData } from '@/lib/useMockData';
 
 interface Project {
   id: string;
@@ -18,22 +19,23 @@ export default function ProjectDetailPage() {
   const params = useParams();
   const project_id = params.project_id as string;
   const [project, setProject] = useState<Project | null>(null);
+  const { getProjectById } = useMockData();
 
   useEffect(() => {
-    const fetchProject = async () => {
-      // replace with API call; mocked for now
-      const data = {
-        id: project_id,
-        title: 'SEO Optimization Campaign',
-        description: 'Improve search rankings for e-commerce website',
-        deadline: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
-        estimated_hours: 40,
-        hourly_rate: 75,
-      };
-      setProject(data);
-    };
-    if (project_id) fetchProject();
-  }, [project_id]);
+    if (project_id) {
+      const proj = getProjectById(project_id);
+      if (proj) {
+        setProject({
+          id: proj.id,
+          title: proj.title,
+          description: proj.description,
+          deadline: proj.deadline,
+          estimated_hours: proj.deliverables.reduce((a,d)=>a+d.estimatedHours,0),
+          hourly_rate: proj.hourlyRate,
+        });
+      }
+    }
+  }, [project_id, getProjectById]);
 
   if (!project) {
     return <p className="p-6 text-center text-gray-600">Loading...</p>;

--- a/components/AdminClientList.tsx
+++ b/components/AdminClientList.tsx
@@ -19,8 +19,10 @@ import {
   RefreshCw,
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { useMockData } from '@/lib/useMockData';
 
 export default function AdminClientList() {
+  const { clients: mockClients } = useMockData();
   const [clients, setClients] = useState<any[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [filteredClients, setFilteredClients] = useState<any[]>([]);
@@ -35,7 +37,12 @@ export default function AdminClientList() {
 
   const fetchClients = async () => {
     setLoading(true);
-     try {
+    try {
+      if (process.env.NEXT_PUBLIC_USE_MOCK === 'true') {
+        setClients(mockClients);
+        setFilteredClients(mockClients);
+        return;
+      }
       const res = await fetch('/api/clients');
       const json = await res.json();
       if (res.ok) {

--- a/components/AdminProjectList.tsx
+++ b/components/AdminProjectList.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/select";
 import { Search as SearchIcon } from "lucide-react";
 import { toast } from "sonner";
+import { useMockData } from '@/lib/useMockData';
 
 interface AdminProject {
   id: string;
@@ -28,6 +29,7 @@ interface AdminProject {
 
 export default function AdminProjectList() {
   const router = useRouter();
+  const { projects: mockProjects } = useMockData();
   const [projects, setProjects] = useState<AdminProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
@@ -43,15 +45,17 @@ export default function AdminProjectList() {
   const fetchProjects = async () => {
     try {
       setLoading(true);
-
-      const res = await fetch('/api/admin/projects');
-      const json = await res.json();
-
-      if (!res.ok) {
-        throw new Error(json.error || 'Request failed');
+      let data: AdminProject[];
+      if (process.env.NEXT_PUBLIC_USE_MOCK === 'true') {
+        data = mockProjects as unknown as AdminProject[];
+      } else {
+        const res = await fetch('/api/admin/projects');
+        const json = await res.json();
+        if (!res.ok) {
+          throw new Error(json.error || 'Request failed');
+        }
+        data = json.data as AdminProject[];
       }
-
-      let data = json.data as AdminProject[];
 
       let filteredData = data || [];
 

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -120,3 +120,37 @@ export const mockProjects: MockProject[] = [
 export function getProjectById(id: string): MockProject | undefined {
   return mockProjects.find(p => p.id === id);
 }
+
+export const mockClients: MockUser[] = Array.from(
+  new Map(mockProjects.map(p => [p.client.id, p.client])).values()
+);
+
+export const mockTalents: MockUser[] = Array.from(
+  new Map(
+    mockProjects
+      .filter(p => p.talent)
+      .map(p => [p.talent!.id, p.talent!])
+  ).values()
+);
+
+export const mockBids: MockBid[] = mockProjects.flatMap(p => p.bids || []);
+
+export interface MockReview {
+  id: string;
+  projectId: string;
+  rating: number;
+  comment: string;
+  createdAt: string;
+  reviewer: { fullName: string };
+}
+
+export const mockReviews: MockReview[] = [
+  {
+    id: 'review1',
+    projectId: 'proj-1',
+    rating: 5,
+    comment: 'Alex did an outstanding job on our SEO strategy.',
+    createdAt: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
+    reviewer: { fullName: 'Sarah Johnson' },
+  },
+];

--- a/lib/useMockData.tsx
+++ b/lib/useMockData.tsx
@@ -1,0 +1,50 @@
+'use client';
+import React, { createContext, useContext } from 'react';
+import {
+  mockProjects,
+  mockClients,
+  mockTalents,
+  mockBids,
+  mockReviews,
+  getProjectById,
+  type MockProject,
+  type MockUser,
+  type MockBid,
+  type MockReview,
+} from './mockData';
+
+interface MockDataContextValue {
+  projects: MockProject[];
+  clients: MockUser[];
+  talents: MockUser[];
+  bids: MockBid[];
+  reviews: MockReview[];
+  getProjectById: (id: string) => MockProject | undefined;
+}
+
+const MockDataContext = createContext<MockDataContextValue>({
+  projects: mockProjects,
+  clients: mockClients,
+  talents: mockTalents,
+  bids: mockBids,
+  reviews: mockReviews,
+  getProjectById,
+});
+
+export const useMockData = () => useContext(MockDataContext);
+
+export function MockDataProvider({ children }: { children: React.ReactNode }) {
+  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+  if (!isMock) return <>{children}</>;
+  const value: MockDataContextValue = {
+    projects: mockProjects,
+    clients: mockClients,
+    talents: mockTalents,
+    bids: mockBids,
+    reviews: mockReviews,
+    getProjectById,
+  };
+  return (
+    <MockDataContext.Provider value={value}>{children}</MockDataContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `MockDataProvider` and `useMockData` hook for global mock data
- wrap layout with mock provider
- integrate provider with talent, client and admin pages
- serve mock data from API endpoints when mock mode is enabled

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687e7094e3a48327a318934b39d26502