### PR TITLE
Refactor mock user loading

### DIFF
--- a/app/api/mock-user/route.ts
+++ b/app/api/mock-user/route.ts
@@ -1,0 +1,9 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getMockUser, type MockRole } from '@/server/getMockUser';
+
+export async function GET(req: NextRequest) {
+  const role = (new URL(req.url).searchParams.get('role') as MockRole) || 'talent';
+  const user = await getMockUser(role);
+  return NextResponse.json({ user });
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,9 +1,9 @@
+// DO NOT import this in client components – will break on process.env access
 import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
 import * as schema from './schema';
 
 const connectionString = process.env.DATABASE_URL;
-
 
 if (!connectionString) {
   throw new Error('DATABASE_URL is not defined in environment variables');

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "dev": "next dev",
+    "predev": "node scripts/check-env.mjs",
     "prebuild": "yarn check-type-imports && yarn type-check",
     "build": "yarn type-check && next build",
     "check-supabase": "node scripts/check-no-supabase.cjs",

--- a/scripts/check-env.mjs
+++ b/scripts/check-env.mjs
@@ -1,0 +1,6 @@
+import 'dotenv/config';
+
+if (!process.env.DATABASE_URL) {
+  console.error('Error: DATABASE_URL is not set in environment variables.');
+  process.exit(1);
+}

--- a/server/getMockUser.ts
+++ b/server/getMockUser.ts
@@ -1,5 +1,6 @@
-import { db } from './db';
-import { users } from './schema';
+// Server-only utility to fetch mock users from the database
+import { db } from '../lib/db';
+import { users } from '../lib/schema';
 import { eq } from 'drizzle-orm/pg-core';
 
 export type MockRole = 'admin' | 'client' | 'talent';


### PR DESCRIPTION
## Summary
- mark `db.ts` as server-only and guard for missing env
- add `/api/mock-user` route for client safe mock user fetching
- move `getMockUser()` to a `server` folder
- fetch mock user via API in `useAuth`
- add env check script and run before `yarn dev`

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687e9845a20c8327abda8fe1c34a63cc