### PR TITLE
Remove local mocks and use Neon DB

### DIFF
--- a/app/admin/projects/details/[id]/page.tsx
+++ b/app/admin/projects/details/[id]/page.tsx
@@ -13,7 +13,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import ExperienceBadge from '@/components/ExperienceBadge';
-import { getProjectById } from '@/lib/mockData';
 
 export default function AdminProjectDetail() {
   const params = useParams();
@@ -36,48 +35,15 @@ export default function AdminProjectDetail() {
   useEffect(() => {
     const fetchProjectData = async () => {
       try {
-        const proj = getProjectById(id);
+        const res = await fetch(`/api/db?table=projects&id=${id}`);
+        const json = await res.json();
+        const proj = json.data?.[0];
         if (proj) {
-          setProject({
-            id: proj.id,
-            title: proj.title,
-            description: proj.description,
-            status: proj.status,
-            category: proj.category,
-            deadline: proj.deadline,
-            estimated_hours: proj.deliverables.reduce((a,d)=>a+d.estimatedHours,0),
-            hourly_rate: proj.hourlyRate,
-            flagged: false,
-            metadata: {
-              marketing: {
-                problem: proj.description,
-                deliverables: proj.deliverables.map(d=>d.title).join(', ')
-              },
-              requestor: {
-                name: proj.client.fullName,
-                company: proj.client.username,
-                email: proj.client.email
-              }
-            },
-            minimum_badge: proj.talent?.badge
-          });
-          setClient({
-            full_name: proj.client.fullName,
-            email: proj.client.email,
-            company: proj.client.username,
-            createdAt: new Date().toISOString()
-          });
-          if (proj.talent) {
-            setTalent({
-              full_name: proj.talent.fullName,
-              email: proj.talent.email,
-              experience_badge: proj.talent.badge,
-              expertise: proj.talent.expertise,
-              location: 'Austin, TX'
-            });
-          }
+          setProject(proj);
+          if (proj.client) setClient(proj.client);
+          if (proj.talent) setTalent(proj.talent);
         }
-        
+
         // Mock reviews
         const mockReviews = [
           {

--- a/app/api/admin/projects/route.ts
+++ b/app/api/admin/projects/route.ts
@@ -3,7 +3,6 @@ import type { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { projects } from '@/lib/schema';
 import { auth } from '@clerk/nextjs/server';
-import { mockProjects } from '@/lib/mockData';
 
 type SessionClaimsWithRole = {
   metadata?: {
@@ -14,7 +13,13 @@ type SessionClaimsWithRole = {
 export async function GET(_req: NextRequest) {
   const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
   if (isMock) {
-    return NextResponse.json({ data: mockProjects });
+    try {
+      const data = await db.select().from(projects).limit(100);
+      return NextResponse.json({ data });
+    } catch (error) {
+      console.error('Error fetching admin projects:', error);
+      return NextResponse.json({ error: 'Failed to fetch projects' }, { status: 500 });
+    }
   }
 
   const { userId, sessionClaims } = await auth();

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -5,12 +5,17 @@ import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm/pg-core';
 import { auth } from '@clerk/nextjs/server';
 import type { SessionClaimsWithRole } from '@/lib/types';
-import { mockClients } from '@/lib/mockData';
 
 export async function GET(_req: NextRequest) {
   const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
   if (isMock) {
-    return NextResponse.json({ data: mockClients });
+    try {
+      const data = await db.select().from(users).where(eq(users.userRole, 'client'));
+      return NextResponse.json({ data });
+    } catch (err) {
+      console.error('Error fetching clients', err);
+      return NextResponse.json({ error: 'Failed to fetch clients' }, { status: 500 });
+    }
   }
 
   const { userId, sessionClaims } = await auth();

--- a/app/talent/projects/details/[project_id]/page.tsx
+++ b/app/talent/projects/details/[project_id]/page.tsx
@@ -30,7 +30,7 @@ export default function ProjectDetailPage() {
           title: proj.title,
           description: proj.description,
           deadline: proj.deadline,
-          estimated_hours: proj.deliverables.reduce((a,d)=>a+d.estimatedHours,0),
+          estimated_hours: proj.deliverables.reduce((a: number, d: any) => a + d.estimatedHours, 0),
           hourly_rate: proj.hourlyRate,
         });
       }

--- a/components/ActiveBidsPanel.tsx
+++ b/components/ActiveBidsPanel.tsx
@@ -2,7 +2,6 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { mockProjects } from "@/lib/mockData";
 
 interface Bid {
   id: string;
@@ -42,17 +41,6 @@ export default function ActiveBidsPanel({ userId }: { userId: string }) {
       } catch (err) {
         console.error("Failed loading bids", err);
       }
-    }
-
-    const mockBids = mockProjects
-      .flatMap(p => p.bids || [])
-      .filter(b => b.userId === userId)
-      .map(b => ({ ...b, professionalId: b.userId }));
-    if (mockBids.length) {
-      setBids(mockBids as Bid[]);
-      const ids = mockBids.map(b => b.projectId);
-      setProjects(mockProjects.filter(p => ids.includes(p.id)) as Project[]);
-      return;
     }
 
     if (userId) load();

--- a/components/WonProjectsCard.tsx
+++ b/components/WonProjectsCard.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { mockProjects } from '@/lib/mockData';
 
 interface Project {
   id: string;
@@ -17,16 +16,6 @@ export default function WonProjectsCard({ userId }: { userId: string }) {
   useEffect(() => {
     async function load() {
       try {
-        if (process.env.NEXT_PUBLIC_USE_MOCK === 'true') {
-          const filtered = mockProjects.filter(
-            (p) =>
-              (p as any).talent?.id === userId &&
-              (p.status === 'awarded' || p.status === 'complete'),
-          );
-          setProjects(filtered as unknown as Project[]);
-          return;
-        }
-
         const res = await fetch('/api/db?table=projects');
         if (!res.ok) {
           console.error('Failed fetching projects:', res.statusText);

--- a/lib/useMockData.tsx
+++ b/lib/useMockData.tsx
@@ -1,50 +1,75 @@
 'use client';
-import React, { createContext, useContext } from 'react';
-import {
-  mockProjects,
-  mockClients,
-  mockTalents,
-  mockBids,
-  mockReviews,
-  getProjectById,
-  type MockProject,
-  type MockUser,
-  type MockBid,
-  type MockReview,
-} from './mockData';
+import React, { createContext, useContext, useState, useEffect } from 'react';
 
 interface MockDataContextValue {
-  projects: MockProject[];
-  clients: MockUser[];
-  talents: MockUser[];
-  bids: MockBid[];
-  reviews: MockReview[];
-  getProjectById: (id: string) => MockProject | undefined;
+  projects: any[];
+  clients: any[];
+  talents: any[];
+  bids: any[];
+  reviews: any[];
+  getProjectById: (id: string) => any | undefined;
 }
 
 const MockDataContext = createContext<MockDataContextValue>({
-  projects: mockProjects,
-  clients: mockClients,
-  talents: mockTalents,
-  bids: mockBids,
-  reviews: mockReviews,
-  getProjectById,
+  projects: [],
+  clients: [],
+  talents: [],
+  bids: [],
+  reviews: [],
+  getProjectById: () => undefined,
 });
 
 export const useMockData = () => useContext(MockDataContext);
 
 export function MockDataProvider({ children }: { children: React.ReactNode }) {
   const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
-  if (!isMock) return <>{children}</>;
+  const [projects, setProjects] = useState<any[]>([]);
+  const [clients, setClients] = useState<any[]>([]);
+  const [talents, setTalents] = useState<any[]>([]);
+  const [bids, setBids] = useState<any[]>([]);
+  const [reviews, setReviews] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!isMock) return;
+    async function load() {
+      try {
+        const [pRes, cRes, tRes, bRes, rRes] = await Promise.all([
+          fetch('/api/db?table=projects'),
+          fetch('/api/db?table=users'),
+          fetch('/api/db?table=talent_profiles'),
+          fetch('/api/db?table=project_bids'),
+          fetch('/api/db?table=project_reviews').catch(() => ({ ok: false } as Response)),
+        ]);
+        const parse = async (res: Response) => (res.ok ? (await res.json()).data || [] : []);
+        const proj = await parse(pRes);
+        const users = await parse(cRes);
+        const tals = await parse(tRes);
+        const bidsData = await parse(bRes);
+        const revs = await parse(rRes);
+        setProjects(proj);
+        setClients(users.filter((u: any) => u.userRole === 'client'));
+        setTalents(tals);
+        setBids(bidsData);
+        setReviews(revs);
+      } catch (err) {
+        console.error('Failed loading mock data', err);
+      }
+    }
+    load();
+  }, [isMock]);
+
+  if (!isMock) {
+    return <>{children}</>;
+  }
+
   const value: MockDataContextValue = {
-    projects: mockProjects,
-    clients: mockClients,
-    talents: mockTalents,
-    bids: mockBids,
-    reviews: mockReviews,
-    getProjectById,
+    projects,
+    clients,
+    talents,
+    bids,
+    reviews,
+    getProjectById: (id: string) => projects.find((p) => p.id === id),
   };
-  return (
-    <MockDataContext.Provider value={value}>{children}</MockDataContext.Provider>
-  );
+
+  return <MockDataContext.Provider value={value}>{children}</MockDataContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- load mock data from Neon instead of `mockData.ts`
- fetch projects from `/api/db` in `WonProjectsCard`
- fetch bids from `/api/db` in `ActiveBidsPanel`
- update admin and client API routes to use Neon for mock mode
- pull project details from Neon in admin and talent pages
- refactor `useMockData` to fetch from Neon

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687e9f7058648327b89c95960f8e1980