### PR TITLE
Add NeonUserSwitcher for dev

### DIFF
--- a/app/api/dev/list-users/route.ts
+++ b/app/api/dev/list-users/route.ts
@@ -1,0 +1,21 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { users } from '@/lib/schema';
+
+export async function GET() {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  try {
+    const data = await db
+      .select({ id: users.id, full_name: users.fullName, username: users.username })
+      .from(users)
+      .limit(100);
+    return NextResponse.json({ users: data });
+  } catch (err) {
+    console.error('list-users error', err);
+    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { AuthProvider } from '@/lib/useAuth';
 import { MockDataProvider } from '@/lib/useMockData';
 import DevRoleSwitcher from '@/components/dev/DevRoleSwitcher';
 import TestUserBadge from '@/components/dev/TestUserBadge';
+import NeonUserSwitcher from '@/components/dev/NeonUserSwitcher';
 
 export const dynamic = 'force-dynamic';
 
@@ -27,6 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {children}
         <Toaster />
         <DevRoleSwitcher />
+        <NeonUserSwitcher />
         <TestUserBadge />
       </AuthProvider>
     </MockDataProvider>

--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -1,0 +1,58 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+interface NeonUser {
+  id: string;
+  username: string | null;
+  full_name: string | null;
+}
+
+export default function NeonUserSwitcher() {
+  const [users, setUsers] = useState<NeonUser[]>([]);
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+    async function load() {
+      try {
+        const res = await fetch('/api/dev/list-users');
+        if (res.ok) {
+          const data = await res.json();
+          setUsers(data.users || []);
+        }
+      } catch (err) {
+        console.error('Failed loading users', err);
+      }
+    }
+    load();
+    const stored = localStorage.getItem('adhok_active_user');
+    if (stored) setValue(stored);
+  }, []);
+
+  const handleChange = (val: string) => {
+    setValue(val);
+    localStorage.setItem('adhok_active_user', val);
+    window.location.reload();
+  };
+
+  if (process.env.NODE_ENV !== 'development') return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-white border rounded-lg shadow p-4 z-50">
+      <p className="text-sm font-semibold mb-2 text-gray-700">Neon User:</p>
+      <Select value={value} onValueChange={handleChange}>
+        <SelectTrigger className="w-48">
+          <SelectValue placeholder="Choose user" />
+        </SelectTrigger>
+        <SelectContent>
+          {users.map((u) => (
+            <SelectItem key={u.id} value={u.id}>
+              {u.username || u.full_name || u.id}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/lib/loadUserSession.ts
+++ b/lib/loadUserSession.ts
@@ -1,0 +1,11 @@
+export function loadUserSession(): string | undefined {
+  if (typeof window !== 'undefined') {
+    const active = localStorage.getItem('adhok_active_user');
+    if (active) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (process.env as any).NEXT_PUBLIC_SELECTED_USER_ID = active;
+      return active;
+    }
+  }
+  return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
+}

--- a/lib/useAuth.tsx
+++ b/lib/useAuth.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { loadUserSession } from './loadUserSession';
 import { useUser } from '@clerk/nextjs';
 
 // Authentication checks are bypassed in mock mode, but the user objects
@@ -55,6 +56,7 @@ const AuthContext = createContext<AuthState>(defaultAuthState);
 export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  loadUserSession();
   const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
   const clerkUser = isMock
     ? { user: null, isSignedIn: false, isLoaded: false }


### PR DESCRIPTION
## Summary
- add new NeonUserSwitcher dev component
- expose `/api/dev/list-users` to get users from Neon
- override NEXT_PUBLIC_SELECTED_USER_ID in `loadUserSession`
- show NeonUserSwitcher in layout when developing

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687ec327d51483278deb229b34e51204