### PR TITLE
Restrict Neon DB usage to server only

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -3,11 +3,11 @@ import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
 import * as schema from './schema';
 
-const connectionString = process.env.DATABASE_URL;
-
-if (!connectionString) {
-  throw new Error('DATABASE_URL is not defined in environment variables');
+if (typeof process.env.DATABASE_URL !== 'string') {
+  throw new Error('DATABASE_URL is not defined in server environment');
 }
+
+const connectionString = process.env.DATABASE_URL;
 
 const sql = neon(connectionString);
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -3,11 +3,11 @@ import { drizzle } from 'drizzle-orm/neon-http';
 import { neon } from '@neondatabase/serverless';
 import * as schema from './schema';
 
-const connectionString = process.env.DATABASE_URL;
-
-if (!connectionString) {
-  throw new Error('DATABASE_URL is not defined in environment variables');
+if (typeof process.env.DATABASE_URL !== 'string') {
+  throw new Error('DATABASE_URL is not defined in server environment');
 }
+
+const connectionString = process.env.DATABASE_URL;
 
 const sql = neon(connectionString);
 

--- a/lib/loadUserSession.ts
+++ b/lib/loadUserSession.ts
@@ -1,5 +1,3 @@
-import { db } from '@/db';
-import { users } from '@/db/schema';
 import { eq } from 'drizzle-orm';
 
 let cachedUserId: string | undefined;
@@ -16,6 +14,12 @@ function resolveUserId(): string | undefined {
 }
 
 export async function loadUserSession() {
+  if (typeof window !== 'undefined') {
+    throw new Error('loadUserSession must run on the server');
+  }
+
+  const { db } = await import('@/db');
+  const { users } = await import('@/db/schema');
   const id = resolveUserId();
   if (!id) throw new Error('No user ID available to load session');
 

--- a/lib/useAuth.tsx
+++ b/lib/useAuth.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { loadUserSession } from './loadUserSession';
 import { useUser } from '@clerk/nextjs';
 
 // Authentication checks are bypassed in mock mode, but the user objects
@@ -56,7 +55,6 @@ const AuthContext = createContext<AuthState>(defaultAuthState);
 export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  loadUserSession();
   const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
   const clerkUser = isMock
     ? { user: null, isSignedIn: false, isLoaded: false }


### PR DESCRIPTION
## Summary
- guard Neon initialization against client use
- ensure `loadUserSession` throws when called on the client and lazily loads the DB
- remove `loadUserSession` call from the client `AuthProvider`

## Testing
- `npx tsc --noEmit`
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687fb6fc1328832791f71e79e07c21d4