### PR TITLE
Implement Neon session context

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,0 +1,14 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { loadUserSession } from '@/lib/server/loadUserSession';
+
+export async function GET() {
+  try {
+    const user = await loadUserSession();
+    return NextResponse.json({ user });
+  } catch (err) {
+    console.error('session error', err);
+    return NextResponse.json({ error: 'No session' }, { status: 404 });
+  }
+}

--- a/app/api/talent/update-profile/route.ts
+++ b/app/api/talent/update-profile/route.ts
@@ -1,13 +1,10 @@
 import { auth } from '@clerk/nextjs/server';
 import { updateTalentProfile } from '@/lib/db/talent';
+import { resolveUserId } from '@/lib/server/loadUserSession';
 
 export async function POST(req: Request) {
-  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
-  const { userId } = isMock
-    ? { userId: process.env.NEXT_PUBLIC_SELECTED_USER_ID }
-    : await auth();
-  const overrideId = process.env.NEXT_PUBLIC_SELECTED_USER_ID;
-  const idToUse = userId || overrideId;
+  const { userId } = await auth().catch(() => ({ userId: undefined }));
+  const idToUse = userId || resolveUserId();
 
   if (!idToUse) return new Response('Unauthorized', { status: 401 });
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -27,11 +27,12 @@ export function Header() {
     admin: `/admin/panel`,
   };
 
-  const getDashboardPath = () => dashboardPaths[userRole] || '/';
+  const getDashboardPath = () =>
+    (userRole ? dashboardPaths[userRole] : undefined) || '/';
 
   const shouldShowDashboard = () => {
     if (!isAuthenticated) return false;
-    const current = dashboardPaths[userRole];
+    const current = userRole ? dashboardPaths[userRole] : undefined;
     return current && pathname !== current;
   };
 

--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useAuth } from '@/lib/client/useAuthContext';
 
 interface NeonUser {
   id: string;
@@ -11,6 +12,7 @@ interface NeonUser {
 export default function NeonUserSwitcher() {
   const [users, setUsers] = useState<NeonUser[]>([]);
   const [value, setValue] = useState('');
+  const { authUser } = useAuth();
 
   useEffect(() => {
     if (process.env.NODE_ENV !== 'development') return;
@@ -53,6 +55,14 @@ export default function NeonUserSwitcher() {
           ))}
         </SelectContent>
       </Select>
+      {authUser && (
+        <p
+          className="text-xs text-gray-500 mt-2"
+          title={`Resolved user: ${authUser.username || authUser.full_name || authUser.id}`}
+        >
+          Resolved: {authUser.username || authUser.full_name || authUser.id}
+        </p>
+      )}
     </div>
   );
 }

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -1,144 +1,56 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { useUser } from '@clerk/nextjs';
 
-// Authentication checks are bypassed in mock mode, but the user objects
-// returned here are real records queried from the database
-
-export type TestRole = 'admin' | 'client' | 'talent';
-
-const FALLBACK_USER = {
-  id: '00000000-0000-0000-0000-000000000001',
-  username: 'mock_talent',
-  userRole: 'talent',
-};
-
-async function fetchTestUser(role: TestRole) {
-  try {
-    const res = await fetch(`/api/test-user?role=${role}`);
-    if (!res.ok) return null;
-    const data = await res.json();
-    return data.user ?? null;
-  } catch (err) {
-    console.error('fetchTestUser error', err);
-    return null;
-  }
-}
-
-type UserRole = 'admin' | 'client' | 'talent';
-
-interface AuthState {
+export interface AuthState {
   userId: string | null;
   username: string | null;
-  userRole: UserRole;
+  userRole: string | null;
   isAdmin: boolean;
-  loading: boolean;
   isAuthenticated: boolean;
+  loading: boolean;
   authUser: any;
-  setDevRole: (role: UserRole) => void;
 }
 
-const defaultAuthState: AuthState = {
+const defaultState: AuthState = {
   userId: null,
   username: null,
-  userRole: 'talent',
+  userRole: null,
   isAdmin: false,
-  loading: true,
   isAuthenticated: false,
+  loading: true,
   authUser: null,
-  setDevRole: () => {},
 };
 
-const AuthContext = createContext<AuthState>(defaultAuthState);
+const AuthContext = createContext<AuthState>(defaultState);
 
 export const useAuth = () => useContext(AuthContext);
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const isMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
-  const clerkUser = isMock
-    ? { user: null, isSignedIn: false, isLoaded: false }
-    : // eslint-disable-next-line react-hooks/rules-of-hooks
-      useUser();
-  const { user, isSignedIn, isLoaded } = clerkUser;
-  const [state, setState] = useState(defaultAuthState);
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(defaultState);
 
   useEffect(() => {
-    async function loadTestUser(role: TestRole) {
-      let userObj = await fetchTestUser(role);
-      if (userObj) {
-        // userObj is an actual user row from the database
-        // even though the login process is mocked
-        console.log('Using test user', {
-          id: userObj.id,
-          role: userObj.userRole,
-          name: userObj.username,
-        });
-        setState({
-          userId: userObj.id,
-          username: userObj.username || userObj.id,
-          userRole: userObj.userRole as UserRole,
-          isAdmin: userObj.userRole === 'admin',
-          isAuthenticated: true,
-          loading: false,
-          authUser: null,
-          setDevRole: (r) => {
-            localStorage.setItem('dev_user_role', r);
-            window.location.reload();
-          },
-        });
-      } else {
-        console.warn(`No test user found for role ${role}, using fallback`);
-        userObj = FALLBACK_USER;
-        setState({
-          userId: userObj.id,
-          username: userObj.username,
-          userRole: userObj.userRole as UserRole,
-          isAdmin: false,
-          isAuthenticated: true,
-          loading: false,
-          authUser: null,
-          setDevRole: (r) => {
-            localStorage.setItem('dev_user_role', r);
-            window.location.reload();
-          },
-        });
-      }
-    }
-
-    if (isMock) {
-      const role =
-        (localStorage.getItem('dev_user_role') as TestRole | null) || 'talent';
-      loadTestUser(role);
-      return;
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      const devRole = localStorage.getItem('dev_user_role') as TestRole | null;
-      if (devRole) {
-        loadTestUser(devRole);
-        return;
-      }
-    }
-
-    if (isLoaded) {
-      if (isSignedIn && user) {
-        const role = (user.publicMetadata?.role as UserRole) || 'talent';
+    async function load() {
+      try {
+        const res = await fetch('/api/session');
+        if (!res.ok) throw new Error('no session');
+        const { user } = await res.json();
         setState({
           userId: user.id,
           username: user.username || user.id,
-          userRole: role,
-          isAdmin: role === 'admin',
+          userRole: user.userRole,
+          isAdmin: user.userRole === 'admin',
           isAuthenticated: true,
           loading: false,
           authUser: user,
-          setDevRole: () => {},
         });
-      } else {
-        setState({ ...defaultAuthState, loading: false });
+      } catch (err) {
+        console.error('Failed loading session', err);
+        setState((s) => ({ ...s, loading: false }));
       }
     }
-  }, [isLoaded, isSignedIn, user, isMock]);
+    load();
+  }, []);
 
   return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
-};
+}

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -1,16 +1,13 @@
 import { eq } from 'drizzle-orm';
 
-let cachedUserId: string | undefined;
-
-function resolveUserId(): string | undefined {
+export function resolveUserId(): string | undefined {
   if (typeof window !== 'undefined') {
-    const fromLocalStorage = localStorage.getItem('adhok_active_user');
-    if (fromLocalStorage) {
-      cachedUserId = fromLocalStorage;
-      return fromLocalStorage;
-    }
+    return (
+      localStorage.getItem('adhok_active_user') ||
+      process.env.NEXT_PUBLIC_SELECTED_USER_ID
+    );
   }
-  return cachedUserId ?? process.env.NEXT_PUBLIC_SELECTED_USER_ID;
+  return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
 }
 
 export async function loadUserSession() {


### PR DESCRIPTION
## Summary
- centralize user session resolution in `loadUserSession`
- expose a `/api/session` endpoint that returns the current user
- replace auth context with a simple provider that loads from `/api/session`
- show resolved Neon user in `NeonUserSwitcher`
- adjust header logic for optional user role
- guard API routes with `resolveUserId`

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_687ff5814dd0832798a0e0c043ce8305