### PR TITLE
Fix session resolution logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ updating `localStorage.dev_user_role`. The `useAuth` hook reads this value to
 load real user records from the database and refreshes the page when a new role is selected.
 ### Neon User Switcher
 
-When developing locally, a `NeonUserSwitcher` is displayed in the bottom right. It stores the selected ID in `localStorage.adhok_active_user` and reloads the page so the app hydrates with that user session. If no runtime value exists the server falls back to the `NEXT_PUBLIC_SELECTED_USER_ID` environment variable.
+When developing locally, a `NeonUserSwitcher` is displayed in the bottom right. It stores the selected ID in `localStorage.adhok_active_user` and reloads the page so the app hydrates with that user session. If no runtime value exists the server falls back to the `NEXT_PUBLIC_SELECTED_USER_ID` environment variable **only in development**.
 
 
 ### Preview Mock Mode

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -4,11 +4,9 @@ import { NextResponse } from 'next/server';
 import { loadUserSession } from '@/lib/server/loadUserSession';
 
 export async function GET() {
-  try {
-    const user = await loadUserSession();
-    return NextResponse.json({ user });
-  } catch (err) {
-    console.error('session error', err);
-    return NextResponse.json({ error: 'No session' }, { status: 404 });
+  const user = await loadUserSession();
+  if (!user) {
+    return NextResponse.json({ user: null });
   }
+  return NextResponse.json({ user });
 }

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -5,8 +5,8 @@ import { eq } from 'drizzle-orm';
  * `adhok_active_user` value from localStorage so developers can easily
  * switch between seeded users. On the server we fall back to Clerk when
  * available. If no Clerk session is present we use the
- * `NEXT_PUBLIC_SELECTED_USER_ID` environment variable so local development
- * works without authentication.
+ * `NEXT_PUBLIC_SELECTED_USER_ID` environment variable in development so
+ * local development works without authentication.
  */
 export async function resolveUserId(): Promise<string | undefined> {
   if (typeof window !== 'undefined') {
@@ -23,7 +23,11 @@ export async function resolveUserId(): Promise<string | undefined> {
     }
   }
 
-  return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
+  if (process.env.NODE_ENV === 'development') {
+    return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
+  }
+
+  return undefined;
 }
 
 export async function loadUserSession() {
@@ -31,14 +35,13 @@ export async function loadUserSession() {
     throw new Error('loadUserSession must run on the server');
   }
 
+  const id = await resolveUserId();
+  if (!id) return null;
+
   const { db } = await import('@/db');
   const { users } = await import('@/db/schema');
-  const id = await resolveUserId();
-  if (!id) throw new Error('No user ID available to load session');
-
   const result = await db.select().from(users).where(eq(users.id, id));
   const user = result?.[0];
 
-  if (!user) throw new Error(`User ${id} not found in Neon`);
-  return user;
+  return user || null;
 }


### PR DESCRIPTION
## Summary
- avoid throwing when resolving session
- return `null` instead of 404 when no user session
- document dev-only fallback for the Neon user switcher

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_6880f3b35b8c83278e8a4bcb9e96fbd2