### PR TITLE
Improve session fallback and client safety

### DIFF
--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -28,8 +28,10 @@ export default function NeonUserSwitcher() {
       }
     }
     load();
-    const stored = localStorage.getItem('adhok_active_user');
-    if (stored) setValue(stored);
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('adhok_active_user');
+      if (stored) setValue(stored);
+    }
   }, []);
 
   const handleChange = (val: string) => {

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -35,6 +35,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const res = await fetch('/api/session');
         if (!res.ok) throw new Error('no session');
         const { user } = await res.json();
+        if (!user) {
+          console.warn('[AuthProvider] Session resolved as null');
+          setState((s) => ({ ...s, loading: false }));
+          return;
+        }
         setState({
           userId: user.id,
           username: user.username || user.id,

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -27,6 +27,7 @@ export async function resolveUserId(): Promise<string | undefined> {
     return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
   }
 
+  console.warn('[resolveUserId] No user ID could be resolved');
   return undefined;
 }
 
@@ -36,7 +37,10 @@ export async function loadUserSession() {
   }
 
   const id = await resolveUserId();
-  if (!id) return null;
+  if (!id) {
+    console.warn('[loadUserSession] Unable to resolve user ID');
+    return null;
+  }
 
   const { db } = await import('@/db');
   const { users } = await import('@/db/schema');


### PR DESCRIPTION
## Summary
- warn when resolving user ID fails
- guard local storage access in dev user switcher
- handle null sessions in AuthProvider

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_6881066bbdf08327ae14409a2849a7cb