### PR TITLE
Fix session fallback and client refresh

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -15,7 +15,7 @@ export function Header() {
   const pathname = usePathname();
   const clerkActive = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
-  const { userId, userRole, username, isAuthenticated, authUser } = useAuth();
+  const { userId, userRole, username, isAuthenticated, authUser, loading } = useAuth();
   const fullName = authUser?.fullName || username;
   const expertiseLevel = authUser?.publicMetadata?.expertiseLevel as string;
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -89,7 +89,7 @@ export function Header() {
           )}
         </div>
 
-        {isAuthenticated ? (
+        {!loading && isAuthenticated ? (
           <div className="flex items-center gap-4">
             <NotificationBell />
             {fullName && (
@@ -109,7 +109,7 @@ export function Header() {
               Sign out
             </Button>
           </div>
-        ) : (
+        ) : !loading ? (
           <div className="flex items-center gap-2">
             <Button
               variant="ghost"
@@ -126,7 +126,7 @@ export function Header() {
               Sign up
             </Button>
           </div>
-        )}
+        ) : null}
       </div>
     </header>
   );

--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -12,7 +12,7 @@ interface NeonUser {
 export default function NeonUserSwitcher() {
   const [users, setUsers] = useState<NeonUser[]>([]);
   const [value, setValue] = useState('');
-  const { authUser } = useAuth();
+  const { authUser, refreshSession } = useAuth();
 
   useEffect(() => {
     if (process.env.NODE_ENV !== 'development') return;
@@ -34,10 +34,10 @@ export default function NeonUserSwitcher() {
     }
   }, []);
 
-  const handleChange = (val: string) => {
+  const handleChange = async (val: string) => {
     setValue(val);
     localStorage.setItem('adhok_active_user', val);
-    window.location.reload();
+    await refreshSession();
   };
 
   if (process.env.NODE_ENV !== 'development') return null;


### PR DESCRIPTION
## Summary
- restore NEXT_PUBLIC_SELECTED_USER_ID fallback
- handle client calls to `loadUserSession`
- expose refreshSession from `useAuthContext`
- update NeonUserSwitcher to refresh without reload
- hide auth buttons until session loads

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_68811a60f7f883278298e36ec31bfadd