### PR TITLE
Fix session override propagation

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -4,9 +4,8 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { loadUserSession } from '@/lib/server/loadUserSession';
 
 export async function GET(req: NextRequest) {
-  const searchParams = new URL(req.url).searchParams;
-  const id = searchParams.get('id') || req.headers.get('x-user-id') || undefined;
-  const user = await loadUserSession(id || undefined);
+  const override = req.headers.get('x-adhok-user-id') || undefined;
+  const user = await loadUserSession(override);
   if (!user) {
     return NextResponse.json({ user: null });
   }

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 
 export interface AuthState {
   userId: string | null;
@@ -31,10 +37,12 @@ export const useAuth = () => useContext(AuthContext);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState(defaultState);
 
-  const fetchSession = async (id?: string) => {
+  const fetchSession = useCallback(async (id?: string) => {
       try {
-        const url = id ? `/api/session?id=${encodeURIComponent(id)}` : '/api/session';
-        const res = await fetch(url);
+        const headers: Record<string, string> = {};
+        const url = '/api/session';
+        if (id) headers['x-adhok-user-id'] = id;
+        const res = await fetch(url, { headers });
         if (!res.ok) throw new Error('no session');
         const { user } = await res.json();
         if (!user) {
@@ -56,7 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         console.error('Failed loading session', err);
         setState((s) => ({ ...s, loading: false, refreshSession: fetchSession }));
       }
-  };
+  }, []);
 
   useEffect(() => {
     fetchSession();

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -1,11 +1,11 @@
 import { eq } from 'drizzle-orm';
 
 /**
- * Resolve the current user ID. In the browser we honour the
- * `adhok_active_user` value from localStorage so developers can easily
- * switch between seeded users. On the server we fall back to Clerk only in
- * production. If no Clerk session is present we use the
- * `NEXT_PUBLIC_SELECTED_USER_ID` environment variable as a fallback.
+ * Resolve the current user ID. The optional override always wins.
+ * When running in the browser we read `adhok_active_user` from localStorage
+ * so developers can easily switch between seeded users. On the server we only
+ * fall back to `NEXT_PUBLIC_SELECTED_USER_ID` during development or tests.
+ * Clerk is checked in production when available.
  */
 
  
@@ -24,15 +24,17 @@ export async function resolveUserId(override?: string): Promise<string | undefin
       const { userId } = await auth();
       if (userId) return userId;
     } catch {
-      // ignore and fall back to env based mock id
+      // ignore and fall through
     }
   }
 
-  if (process.env.NEXT_PUBLIC_SELECTED_USER_ID) {
+  if (process.env.NODE_ENV !== 'production' && process.env.NEXT_PUBLIC_SELECTED_USER_ID) {
     return process.env.NEXT_PUBLIC_SELECTED_USER_ID;
   }
 
-  console.warn('[resolveUserId] No user ID could be resolved');
+  if (process.env.NODE_ENV === 'development') {
+    console.warn('[resolveUserId] No user ID could be resolved');
+  }
   return undefined;
 }
 
@@ -44,7 +46,9 @@ export async function loadUserSession(overrideId?: string) {
 
   const id = await resolveUserId(overrideId);
   if (!id) {
-    console.warn('[loadUserSession] Unable to resolve user ID');
+    if (process.env.NODE_ENV === 'development') {
+      console.warn('[loadUserSession] Unable to resolve user ID');
+    }
     return null;
   }
 

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -44,6 +44,8 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('uid').textContent).toBe('u2');
     });
     expect(refreshSpy).toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenLastCalledWith('/api/session?id=u2');
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/session', {
+      headers: { 'x-adhok-user-id': 'u2' },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- include `x-adhok-user-id` header when refreshing session
- use header in `/api/session` and adjust server utilities
- clean up `resolveUserId` debug logging
- update tests for new header behaviour

## Testing
- `yarn verify`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688263de5bfc832797ab53998d68a343