### PR TITLE
Implement session override support

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -4,7 +4,9 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { loadUserSession } from '@/lib/server/loadUserSession';
 
 export async function GET(req: NextRequest) {
-  const override = req.headers.get('x-adhok-user-id') || undefined;
+  const { searchParams } = new URL(req.url);
+  const queryId = searchParams.get('userId');
+  const override = req.headers.get('x-adhok-user-id') || queryId || undefined;
   const user = await loadUserSession(override);
   if (!user) {
     return NextResponse.json({ user: null });

--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -37,11 +37,7 @@ export default function NeonUserSwitcher() {
   const handleChange = async (val: string) => {
     setValue(val);
     localStorage.setItem('adhok_active_user', val);
-    const before = authUser?.id;
-    await refreshSession(val);
-    if (authUser && before === authUser.id) {
-      console.error('[NeonUserSwitcher] refreshSession did not update context');
-    }
+    await refreshSession({ userId: val });
     if (typeof window !== 'undefined') {
       window.location.reload();
     }

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -16,7 +16,7 @@ export interface AuthState {
   isAuthenticated: boolean;
   loading: boolean;
   authUser: any;
-  refreshSession: (id?: string) => Promise<void>;
+  refreshSession: (opts?: { userId?: string }) => Promise<void>;
 }
 
 const defaultState: AuthState = {
@@ -37,11 +37,11 @@ export const useAuth = () => useContext(AuthContext);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [state, setState] = useState(defaultState);
 
-  const fetchSession = useCallback(async (id?: string) => {
+  const fetchSession = useCallback(async (opts?: { userId?: string }) => {
       try {
         const headers: Record<string, string> = {};
         const url = '/api/session';
-        if (id) headers['x-adhok-user-id'] = id;
+        if (opts?.userId) headers['x-adhok-user-id'] = opts.userId;
         const res = await fetch(url, { headers });
         if (!res.ok) throw new Error('no session');
         const { user } = await res.json();

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -8,7 +8,13 @@ function TestComponent({ onRefresh }: { onRefresh: () => void }) {
   return (
     <div>
       <span data-testid="uid">{userId}</span>
-      <button data-testid="refresh" onClick={() => { refreshSession('u2'); onRefresh(); }} />
+      <button
+        data-testid="refresh"
+        onClick={() => {
+          refreshSession({ userId: 'u2' });
+          onRefresh();
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow passing a userId override when fetching sessions
- handle the override in `/api/session`
- pass the new option from NeonUserSwitcher
- update AuthProvider test for the new API

## Testing
- `yarn verify`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68828715ff7c8327949cf7edbaff8553