### PR TITLE
Fix client upload session handling

### DIFF
--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -1,6 +1,9 @@
 import { getClientProjects } from '@/lib/apiHandlers/clients';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { loadUserSession } from '@/lib/server/loadUserSession';
+import { db } from '@/lib/db';
+import { projects } from '@/lib/schema';
 import type { SessionClaimsWithRole } from '@/lib/types';
 
 type RouteContext = { params: Promise<{ id: string }> };
@@ -37,5 +40,40 @@ export async function GET(_req: NextRequest, ctx: RouteContext) {
   } catch (error) {
     console.error('Error fetching client projects:', error);
     return NextResponse.json({ error: 'Failed to fetch client projects' }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest, ctx: RouteContext) {
+  const sessionUser = await loadUserSession(req);
+  if (!sessionUser || sessionUser.user_role !== 'client') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { id } = await ctx.params;
+  if (sessionUser.id !== id) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  let data: { title: string; description: string };
+  try {
+    data = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  try {
+    const [project] = await db
+      .insert(projects)
+      .values({
+        title: data.title,
+        description: data.description,
+        clientId: sessionUser.id,
+        createdBy: sessionUser.id,
+      })
+      .returning();
+    return NextResponse.json({ project });
+  } catch (err) {
+    console.error('Error creating project:', err);
+    return NextResponse.json({ error: 'Failed to create project' }, { status: 500 });
   }
 }

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -4,10 +4,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { loadUserSession } from '@/lib/server/loadUserSession';
 
 export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const queryId = searchParams.get('userId');
-  const override = req.headers.get('x-user-id') || queryId || undefined;
-  const user = await loadUserSession(override);
+  const user = await loadUserSession(req);
   if (!user) {
     return NextResponse.json({ user: null });
   }

--- a/app/api/talent/profile/route.ts
+++ b/app/api/talent/profile/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
     const { auth } = await import('@clerk/nextjs/server');
     userId = (await auth()).userId;
   }
-  const id = paramId || userId || (await resolveUserId());
+  const id = paramId || userId || (await resolveUserId(req));
   if (!id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -41,7 +41,7 @@ export async function POST(req: NextRequest) {
     const { auth } = await import('@clerk/nextjs/server');
     userId = (await auth()).userId;
   }
-  const id = userId || (await resolveUserId());
+  const id = userId || (await resolveUserId(req));
   if (!id) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }

--- a/app/api/talent/update-profile/route.ts
+++ b/app/api/talent/update-profile/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
     const { auth } = await import('@clerk/nextjs/server');
     userId = (await auth()).userId;
   }
-  const idToUse = userId || (await resolveUserId());
+  const idToUse = userId || (await resolveUserId(req));
 
   if (!idToUse) return new Response('Unauthorized', { status: 401 });
 

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -49,7 +49,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const headers: Record<string, string> = {};
         const url = '/api/session';
         const override = opts?.userId ?? storedId ?? undefined;
-        if (override) headers['x-user-id'] = override;
+        if (override) headers['adhok_active_user'] = override;
         const res = await fetch(url, { headers });
         if (!res.ok) throw new Error('no session');
         const { user } = await res.json();

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,7 @@ function safeRedirect(path: string, req: NextRequest) {
 
 export async function middleware(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
-  const userId = await resolveUserId();
+  const userId = await resolveUserId(req);
 
   let user_role: string | undefined;
   if (userId) {

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -51,7 +51,7 @@ describe('AuthProvider', () => {
     });
     expect(refreshSpy).toHaveBeenCalled();
     expect(fetchMock).toHaveBeenLastCalledWith('/api/session', {
-      headers: { 'x-user-id': 'u2' },
+      headers: { adhok_active_user: 'u2' },
     });
   });
 });


### PR DESCRIPTION
## Summary
- load session using `adhok_active_user` header/query
- send active user header from the auth context
- update middleware and talent API routes to pass the request
- add POST handler for client project upload
- adjust tests for new header

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_6888cef225a483279882d91e42cbea1b