### PR TITLE
Implement override session fetching

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -4,7 +4,10 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { loadUserSession } from '@/lib/server/loadUserSession';
 
 export async function GET(req: NextRequest) {
-  const user = await loadUserSession(req);
+  const headerId = req.headers.get('adhok_active_user');
+  const queryId = new URL(req.url).searchParams.get('adhok_active_user');
+  const override = headerId || queryId || undefined;
+  const user = await loadUserSession(override);
   if (!user) {
     return NextResponse.json({ user: null });
   }

--- a/app/client/upload/page.tsx
+++ b/app/client/upload/page.tsx
@@ -8,7 +8,6 @@ export default function ClientUploadPage() {
   const { authUser, loading } = useAuth();
   const router = useRouter();
 
-  console.log('ClientUploadPage authUser', authUser);
 
   useEffect(() => {
     if (!loading && (!authUser || authUser.user_role !== 'client')) {

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -36,53 +36,55 @@ const AuthContext = createContext<AuthState>(defaultState);
 export const useAuth = () => useContext(AuthContext);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [state, setState] = useState(defaultState);
-  const storedId =
-    typeof window !== 'undefined'
-      ? window.localStorage.getItem('adhok_active_user')
-      : null;
+  const [state, setState] = useState<Omit<AuthState, 'refreshSession'>>({
+    userId: null as string | null,
+    username: null as string | null,
+    userRole: null as string | null,
+    isAdmin: false,
+    isAuthenticated: false,
+    loading: true,
+    authUser: null as any,
+  });
   const hasFetchedOnce = useRef(false);
 
-  const fetchSession = useCallback(
-    async (opts?: { userId?: string }) => {
-      try {
-        const headers: Record<string, string> = {};
-        const url = '/api/session';
-        const override = opts?.userId ?? storedId ?? undefined;
-        if (override) headers['adhok_active_user'] = override;
-        const res = await fetch(url, { headers });
-        if (!res.ok) throw new Error('no session');
-        const { user } = await res.json();
-        if (!user) {
-          console.warn('[AuthProvider] Session resolved as null');
-          if (!storedId || opts?.userId) {
-            setState((s) => ({ ...s, loading: false, refreshSession: fetchSession }));
-          }
-          return;
-        }
-        setState({
-          userId: user.id,
-          username: user.username || user.id,
-          userRole: user.user_role,
-          isAdmin: user.user_role === 'admin',
-          isAuthenticated: true,
-          loading: false,
-          authUser: user,
-          refreshSession: fetchSession,
-        });
-      } catch (err) {
-        console.error('Failed loading session', err);
-        setState((s) => ({ ...s, loading: false, refreshSession: fetchSession }));
+  const refreshSession = useCallback(async (opts?: { userId?: string }) => {
+    try {
+      const headers: Record<string, string> = {};
+      const override =
+        opts?.userId ??
+        (typeof window !== 'undefined'
+          ? window.localStorage.getItem('adhok_active_user') || undefined
+          : undefined);
+      if (override) headers['adhok_active_user'] = override;
+      const res = await fetch('/api/session', { headers });
+      if (!res.ok) throw new Error('no session');
+      const { user } = await res.json();
+      if (!user) {
+        console.warn('[AuthProvider] Session resolved as null');
+        setState((s) => ({ ...s, loading: false }));
+        return;
       }
-    },
-    [storedId]
-  );
+      setState({
+        userId: user.id,
+        username: user.username || user.id,
+        userRole: user.user_role,
+        isAdmin: user.user_role === 'admin',
+        isAuthenticated: true,
+        loading: false,
+        authUser: user,
+      });
+    } catch (err) {
+      console.error('Failed loading session', err);
+      setState((s) => ({ ...s, loading: false }));
+    }
+  }, []);
 
   useEffect(() => {
     if (hasFetchedOnce.current) return;
     hasFetchedOnce.current = true;
-    fetchSession();
-  }, [fetchSession]);
+    refreshSession();
+  }, [refreshSession]);
 
-  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+  const value = { ...state, refreshSession };
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- update `/api/session` to pass override ID to `loadUserSession`
- clean up client upload page
- keep a stable `refreshSession` inside `AuthProvider`

## Testing
- `yarn test`
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_688a0e935ff88327b8b1698d6dd5f9c8