### PR TITLE
Fix auth session updates and upload routing

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -98,7 +98,13 @@ export default function ClientDashboard() {
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4 mb-6">
         <h1 className="text-2xl sm:text-3xl font-bold text-indigo-900">Client Dashboard</h1>
         <Button
-          onClick={() => router.push('/client/upload')}
+          onClick={() => {
+            if (isAuthenticated && userRole === 'client') {
+              router.push('/client/upload');
+            } else {
+              router.push('/');
+            }
+          }}
           className="w-full sm:w-auto bg-[#00D1C1] text-white hover:bg-[#00b4ab]"
         >
           <Plus className="mr-2 w-4 h-4" /> Post New Project

--- a/app/client/upload/page.tsx
+++ b/app/client/upload/page.tsx
@@ -8,15 +8,18 @@ export default function ClientUploadPage() {
   const { authUser, loading } = useAuth();
   const router = useRouter();
 
-
   useEffect(() => {
     if (!loading && (!authUser || authUser.user_role !== 'client')) {
       router.replace('/');
     }
   }, [authUser, loading, router]);
 
-  if (loading || !authUser) {
+  if (loading) {
     return <p className="p-6 text-center text-gray-600">Loading...</p>;
+  }
+
+  if (!authUser || authUser.user_role !== 'client') {
+    return null;
   }
 
   return (

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -47,43 +47,51 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   });
   const hasFetchedOnce = useRef(false);
 
-  const refreshSession = useCallback(async (opts?: { userId?: string }) => {
-    try {
-      const headers: Record<string, string> = {};
-      const override =
-        opts?.userId ??
-        (typeof window !== 'undefined'
-          ? window.localStorage.getItem('adhok_active_user') || undefined
-          : undefined);
-      if (override) headers['adhok_active_user'] = override;
-      const res = await fetch('/api/session', { headers });
-      if (!res.ok) throw new Error('no session');
-      const { user } = await res.json();
-      if (!user) {
-        console.warn('[AuthProvider] Session resolved as null');
-        setState((s) => ({ ...s, loading: false }));
-        return;
-      }
-      setState({
-        userId: user.id,
-        username: user.username || user.id,
-        userRole: user.user_role,
-        isAdmin: user.user_role === 'admin',
-        isAuthenticated: true,
-        loading: false,
-        authUser: user,
-      });
-    } catch (err) {
-      console.error('Failed loading session', err);
-      setState((s) => ({ ...s, loading: false }));
-    }
+  const fetchSession = useCallback(async (overrideId?: string) => {
+    const headers: Record<string, string> = {};
+    const override =
+      overrideId ??
+      (typeof window !== 'undefined'
+        ? window.localStorage.getItem('adhok_active_user') || undefined
+        : undefined);
+    if (override) headers['adhok_active_user'] = override;
+    const res = await fetch('/api/session', { headers });
+    if (!res.ok) throw new Error('no session');
+    const { user } = await res.json();
+    return user as any | null;
   }, []);
+
+  const refreshSession = useCallback(
+    async (opts?: { userId?: string }) => {
+      try {
+        const user = await fetchSession(opts?.userId);
+        if (!user) {
+          console.warn('[AuthProvider] Session resolved as null');
+          setState((s) => ({ ...s, loading: false }));
+          return;
+        }
+        setState({
+          userId: user.id,
+          username: user.username || user.id,
+          userRole: user.user_role,
+          isAdmin: user.user_role === 'admin',
+          isAuthenticated: true,
+          loading: false,
+          authUser: user,
+        });
+      } catch (err) {
+        console.error('Failed loading session', err);
+        setState((s) => ({ ...s, loading: false }));
+      }
+    },
+    [fetchSession]
+  );
 
   useEffect(() => {
     if (hasFetchedOnce.current) return;
     hasFetchedOnce.current = true;
     refreshSession();
-  }, [refreshSession]);
+  }, [refreshSession, fetchSession]);
 
   const value = { ...state, refreshSession };
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/scripts/check-eslint-versions.cjs
+++ b/scripts/check-eslint-versions.cjs
@@ -18,9 +18,15 @@ if (pkg.resolutions && (pkg.resolutions['@typescript-eslint/eslint-plugin'] || p
   fail('Do not use resolutions for @typescript-eslint packages');
 }
 const lock = fs.readFileSync('yarn.lock', 'utf8');
-if (!lock.includes(`@typescript-eslint/parser/-/parser-${expected}.tgz`)) {
+const parserOk =
+  lock.includes(`@typescript-eslint/parser/-/parser-${expected}.tgz`) ||
+  lock.includes(`@typescript-eslint/parser@npm:${expected}`);
+if (!parserOk) {
   fail('yarn.lock missing parser version');
 }
-if (!lock.includes(`@typescript-eslint/eslint-plugin/-/eslint-plugin-${expected}.tgz`)) {
+const pluginOk =
+  lock.includes(`@typescript-eslint/eslint-plugin/-/eslint-plugin-${expected}.tgz`) ||
+  lock.includes(`@typescript-eslint/eslint-plugin@npm:${expected}`);
+if (!pluginOk) {
   fail('yarn.lock missing eslint-plugin version');
 }

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -54,4 +54,34 @@ describe('AuthProvider', () => {
       headers: { adhok_active_user: 'u2' },
     });
   });
+
+  it('keeps previous user if refresh resolves with null', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: { id: 'u1', username: 'u1', user_role: 'client' } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ user: null }),
+      });
+    // @ts-ignore
+    global.fetch = fetchMock;
+
+    render(
+      <AuthProvider>
+        <TestComponent onRefresh={() => {}} />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('uid').textContent).toBe('u1');
+    });
+
+    fireEvent.click(screen.getByTestId('refresh'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('uid').textContent).toBe('u1');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- guard upload page and only render when the user is a client
- only push the upload route for authenticated clients
- refactor auth context to expose `fetchSession` and use it within `refreshSession`
- relax eslint version check for Yarn v4 lockfile format
- test `refreshSession` when the backend returns `null`

## Testing
- `yarn verify`
- `node scripts/check-eslint-versions.cjs && echo success`

------
https://chatgpt.com/codex/tasks/task_e_688a60ea971c8327b963f9b120a2ffc7