### PR TITLE
Allow talent-led projects and dual dashboards

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -36,7 +36,10 @@ export default function ClientDashboard() {
   } = useAuth();
 
   useEffect(() => {
-    if (!authLoading && (!authUser || authUser.user_role !== 'client')) {
+    if (
+      !authLoading &&
+      (!authUser || (authUser.user_role !== 'client' && !authUser.isClient))
+    ) {
       router.replace('/');
     }
   }, [authLoading, authUser, router]);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -50,11 +50,27 @@ export function Header() {
     admin: `/admin/panel`,
   };
 
-  const getDashboardPath = () =>
-    (userRole ? dashboardPaths[userRole] : undefined) || '/';
+  const getDashboardPath = () => {
+    if (authUser?.isClient && userRole === 'talent') {
+      return pathname.startsWith('/client')
+        ? '/talent/dashboard'
+        : '/client/dashboard';
+    }
+    if (authUser?.isClient && userRole === 'client') {
+      return pathname.startsWith('/talent')
+        ? '/client/dashboard'
+        : '/talent/dashboard';
+    }
+    return (userRole ? dashboardPaths[userRole] : undefined) || '/';
+  };
 
   const shouldShowDashboard = () => {
     if (!isAuthenticated) return false;
+    if (authUser?.isClient && (userRole === 'talent' || userRole === 'client')) {
+      const talentPath = '/talent/dashboard';
+      const clientPath = '/client/dashboard';
+      return pathname !== talentPath && pathname !== clientPath;
+    }
     const current = userRole ? dashboardPaths[userRole] : undefined;
     return current && pathname !== current;
   };

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -13,6 +13,7 @@ export interface AuthState {
   userId: string | null;
   username: string | null;
   userRole: string | null;
+  isClient?: boolean;
   isAdmin: boolean;
   isAuthenticated: boolean;
   loading: boolean;
@@ -24,6 +25,7 @@ const defaultState: AuthState = {
   userId: null,
   username: null,
   userRole: null,
+  isClient: false,
   isAdmin: false,
   isAuthenticated: false,
   loading: true,
@@ -40,6 +42,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     userId: null as string | null,
     username: null as string | null,
     userRole: null as string | null,
+    isClient: false,
     isAdmin: false,
     isAuthenticated: false,
     loading: true,
@@ -68,6 +71,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         userId: user.id,
         username: user.username || user.id,
         userRole: user.user_role,
+        isClient: user.isClient || false,
         isAdmin: user.user_role === 'admin',
         isAuthenticated: true,
         loading: false,

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -63,20 +63,27 @@ export async function loadUserSession(
   }
 
   try {
-    const { db } = await import('@/db');
-    const { users } = await import('@/db/schema');
+    const { db } = await import('@/lib/db');
+    const { users, clientProfiles } = await import('@/lib/schema');
     const result = await db
       .select({
         id: users.id,
         username: users.username,
         full_name: users.full_name,
+        email: users.email,
         user_role: users.user_role,
       })
       .from(users)
       .where(eq(users.id, id))
       .limit(1);
     const user = result[0];
-    return user || null;
+    if (!user) return null;
+    const hasProfile = await db
+      .select({ id: clientProfiles.id })
+      .from(clientProfiles)
+      .where(eq(clientProfiles.id, id))
+      .limit(1);
+    return { ...user, isClient: hasProfile.length > 0 };
   } catch (err) {
     console.error('loadUserSession db error', err);
     return null;


### PR DESCRIPTION
## Summary
- let talent users create projects by updating the client projects API
- mark a talent user as a client when they create a project
- expose client profile info in `loadUserSession`
- surface the client flag in the auth context
- show alternate dashboard links in the header when a user is both
- allow dual-role users to access the client dashboard

## Testing
- `yarn type-check`
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_688a607537448327949872caabbb8ac9