### PR TITLE
Fix session debug flow

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: NextRequest) {
   const headerId = req.headers.get('adhok_active_user');
   const queryId = new URL(req.url).searchParams.get('adhok_active_user');
   const override = headerId || queryId || undefined;
+  console.log('[api/session] incoming', { headerId, queryId, override });
   const user = await loadUserSession(override);
   if (!user) {
     return NextResponse.json({ user: null });

--- a/app/client/upload/page.tsx
+++ b/app/client/upload/page.tsx
@@ -9,7 +9,7 @@ export default function ClientUploadPage() {
   const router = useRouter();
 
   useEffect(() => {
-    if (!loading && (!authUser || authUser.user_role !== 'client')) {
+    if (!loading && (authUser === null || authUser.user_role !== 'client')) {
       router.replace('/');
     }
   }, [authUser, loading, router]);

--- a/components/dev/NeonUserSwitcher.tsx
+++ b/components/dev/NeonUserSwitcher.tsx
@@ -48,7 +48,9 @@ export default function NeonUserSwitcher() {
     setPendingId(val);
     setSwitching(true);
     localStorage.setItem('adhok_active_user', val);
+    console.log('[NeonUserSwitcher] set adhok_active_user', val);
     await refreshSession({ userId: val });
+    console.log('[NeonUserSwitcher] refreshSession called');
   };
 
   useEffect(() => {

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -58,7 +58,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       (typeof window !== 'undefined'
         ? window.localStorage.getItem('adhok_active_user') || undefined
         : undefined);
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[fetchSession] localStorage adhok_active_user', override);
+    }
     if (override) headers['adhok_active_user'] = override;
+    console.log('[fetchSession] headers', headers);
 
     const res = await fetch('/api/session', { headers });
     if (!res.ok) throw new Error('no session');

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -35,6 +35,10 @@ export async function resolveUserId(
     }
   }
 
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[resolveUserId] override', override);
+  }
+
   if (override) return override;
   if (typeof window !== 'undefined') {
     return localStorage.getItem('adhok_active_user') || undefined;
@@ -68,6 +72,9 @@ export async function loadUserSession(
   }
 
   const id = await resolveUserId(overrideOrReq);
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[loadUserSession] resolved id', id);
+  }
   if (!id) {
     if (process.env.NODE_ENV === 'development') {
       console.warn('[loadUserSession] Unable to resolve user ID');
@@ -96,7 +103,11 @@ export async function loadUserSession(
       .from(clientProfiles)
       .where(eq(clientProfiles.id, id))
       .limit(1);
-    return { ...user, isClient: hasProfile.length > 0 };
+    const session = { ...user, isClient: hasProfile.length > 0 };
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[loadUserSession] session', session);
+    }
+    return session;
   } catch (err) {
     console.error('loadUserSession db error', err);
     return null;


### PR DESCRIPTION
## Summary
- log localStorage use in fetchSession
- log incoming user headers in `/api/session`
- report override value in resolveUserId and loadUserSession
- log user session details
- adjust client upload redirect logic
- log when NeonUserSwitcher stores new user id

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_688a93721c18832785554da98820c735