### PR TITLE
Fix header retrieval in resolveUserId

### DIFF
--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
-import { headers as nextHeaders } from 'next/headers';
+import { headers } from 'next/headers';
 
 /**
  * Resolve the current user ID. The optional override always wins.
@@ -23,8 +23,8 @@ export async function resolveUserId(
     override = headerVal || queryVal || undefined;
   } else {
     try {
-      const headerList = await nextHeaders();
-      override = headerList.get('adhok_active_user') || undefined;
+      const hdrs = await headers();
+      override = hdrs.get('adhok_active_user') || undefined;
       if (!override && process.env.NODE_ENV === 'development') {
         console.warn('[resolveUserId] headers missing adhok_active_user');
       }


### PR DESCRIPTION
## Summary
- update header retrieval in `resolveUserId` to await `headers`

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_688b87a5ede483279cb7e272c29e6ae1