### PR TITLE
Fix client session handling

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -13,9 +13,14 @@ export async function GET(req: NextRequest) {
     console.warn('[api/session] adhok_active_user header missing');
   }
   console.log('[api/session] incoming', { headerId, queryId, override });
-  const user = await loadUserSession(override);
-  if (!user) {
+  try {
+    const user = await loadUserSession(override);
+    if (!user) {
+      return NextResponse.json({ user: null });
+    }
+    return NextResponse.json({ user });
+  } catch (err) {
+    console.error('[api/session] failed to load session', err);
     return NextResponse.json({ user: null });
   }
-  return NextResponse.json({ user });
 }

--- a/app/client/upload/page.tsx
+++ b/app/client/upload/page.tsx
@@ -9,10 +9,10 @@ export default function ClientUploadPage() {
   const router = useRouter();
 
   useEffect(() => {
-    if (!loading && !isClient && !isAuthenticated) {
+    if (!loading && !isClient) {
       router.replace('/');
     }
-  }, [isClient, isAuthenticated, loading, router]);
+  }, [isClient, loading, router]);
 
   if (loading) {
     return <p className="p-6 text-center text-gray-600">Loading...</p>;

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -88,7 +88,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const user = await fetchSession(opts?.userId);
         if (!user) {
           console.warn('[AuthProvider] Session resolved as null');
-          setState((s) => ({ ...s, loading: false }));
+          setState({
+            userId: null,
+            username: null,
+            userRole: null,
+            isClient: false,
+            isAdmin: false,
+            isAuthenticated: false,
+            loading: false,
+            authUser: null,
+          });
           return;
         }
         setState({
@@ -106,7 +115,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       } catch (err) {
         console.error('Failed loading session', err);
-        setState((s) => ({ ...s, loading: false }));
+        setState({
+          userId: null,
+          username: null,
+          userRole: null,
+          isClient: false,
+          isAdmin: false,
+          isAuthenticated: false,
+          loading: false,
+          authUser: null,
+        });
       }
     },
     [fetchSession]

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -97,7 +97,12 @@ export async function loadUserSession(
       .where(eq(users.id, id))
       .limit(1);
     const user = result[0];
-    if (!user) return null;
+    if (!user) {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('[loadUserSession] no user found for id', id);
+      }
+      return null;
+    }
     const hasProfile = await db
       .select({ id: clientProfiles.id })
       .from(clientProfiles)


### PR DESCRIPTION
## Summary
- handle missing users gracefully when loading a session
- guard session API with try/catch and return `{ user: null }` on error
- reset auth context when session fetch fails
- update client upload gate to only check for client role

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_688cd945d5a88327998302e2a1364a84