### PR TITLE
Add project deadline support

### DIFF
--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -58,11 +58,15 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 
-  let data: { title: string; description: string };
+  let data: { title: string; description: string; deadline: string };
   try {
     data = await req.json();
   } catch {
     return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  if (!data.title || !data.description || !data.deadline) {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
   if (sessionUser.user_role === 'talent') {
@@ -86,6 +90,7 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
       .values({
         title: data.title,
         description: data.description,
+        deadline: new Date(data.deadline),
         clientId: sessionUser.id,
         createdBy: sessionUser.id,
       })

--- a/app/api/upload-project/route.ts
+++ b/app/api/upload-project/route.ts
@@ -11,8 +11,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
-  const { title, description, clientName, company, email } = body || {};
-  if (!title || !description || !email) {
+  const { title, description, clientName, company, email, deadline } = body || {};
+  if (!title || !description || !email || !deadline) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
@@ -38,6 +38,7 @@ export async function POST(req: NextRequest) {
       .values({
         title,
         description,
+        deadline: new Date(deadline),
         clientId: user.id,
         createdBy: user.id,
       })

--- a/app/talent/projects/page.tsx
+++ b/app/talent/projects/page.tsx
@@ -115,6 +115,11 @@ export default function ProjectsPage() {
       return;
     }
 
+    if (new Date(selectedProject.deadline) < new Date()) {
+      toast.error('Bidding has closed for this project');
+      return;
+    }
+
     const ratePerHour = parseFloat(bidAmount);
     if (isNaN(ratePerHour) || ratePerHour <= 0) {
       toast.error('Please enter a valid hourly rate');

--- a/components/ClientProjectsList.tsx
+++ b/components/ClientProjectsList.tsx
@@ -70,9 +70,13 @@ export default function ClientProjectsList({ projects }: Props) {
     );
   }
 
+  const sortedProjects = [...projects].sort(
+    (a, b) => new Date(a.deadline).getTime() - new Date(b.deadline).getTime()
+  );
+
   return (
     <>
-      {projects.map((proj) => (
+      {sortedProjects.map((proj) => (
         <div key={proj.id} className="border rounded-lg p-4 shadow-sm">
           <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
             <div className="flex-1 min-w-0">

--- a/components/ProjectReviewCard.tsx
+++ b/components/ProjectReviewCard.tsx
@@ -18,6 +18,7 @@ interface ProjectReviewProps {
     preferredTools: string;
     brandVoice: string;
     briefFile?: string | null;
+    deadline: string;
   };
 }
 
@@ -51,6 +52,7 @@ export function ProjectReviewCard({ project }: ProjectReviewProps) {
             <li><b>Expert Type:</b> {project.expertType}</li>
             <li><b>Target Audience:</b> {project.targetAudience}</li>
             <li><b>Brand Voice:</b> {project.brandVoice}</li>
+            <li><b>Deadline:</b> {new Date(project.deadline).toLocaleDateString()}</li>
           </ul>
         </div>
         <Separator />

--- a/components/ProjectUploadFlow.tsx
+++ b/components/ProjectUploadFlow.tsx
@@ -62,6 +62,7 @@ export function ProjectUploadFlow() {
     deliverables: '',
     preferredTools: '',
     brandVoice: '',
+    deadline: '',
   });
 
   const getEstimatedHours = () =>
@@ -102,6 +103,16 @@ export function ProjectUploadFlow() {
   const handleSubmit = async () => {
     setSubmitting(true);
     try {
+      if (!form.deadline) {
+        toast.error('Please select a deadline');
+        setSubmitting(false);
+        return;
+      }
+      if (new Date(form.deadline) < new Date()) {
+        toast.error('Deadline must be in the future');
+        setSubmitting(false);
+        return;
+      }
       const res = await fetch('/api/upload-project', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -111,6 +122,7 @@ export function ProjectUploadFlow() {
           clientName: form.clientName,
           company: form.company,
           email: form.email,
+          deadline: form.deadline,
         }),
       });
 
@@ -302,6 +314,14 @@ export function ProjectUploadFlow() {
                       <p className="text-sm text-gray-600 mt-1">Estimated Hours: {hours} hrs</p>
                     ) : null;
                   })()}
+                </div>
+                <div>
+                  <label className="block font-medium mb-1">Deadline</label>
+                  <Input
+                    type="date"
+                    value={form.deadline}
+                    onChange={(e) => setForm({ ...form, deadline: e.target.value })}
+                  />
                 </div>
                 <Textarea
                   placeholder="Target Audience"


### PR DESCRIPTION
## Summary
- add `deadline` to project upload form and validation
- show deadline in project review card
- send deadline to backend and store in DB
- sort projects by deadline in client dashboard
- block bidding on expired projects

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_688d5dcdd0148327b8626e448a150b85