### PR TITLE
Fix user session override handling

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -16,7 +16,10 @@ export async function GET(req: NextRequest) {
   try {
     const user = await loadUserSession(override);
     if (!user) {
-      return NextResponse.json({ user: null });
+      if (override) {
+        console.warn('[api/session] no user found for override', override);
+      }
+      return NextResponse.json({ user: { id: null, user_role: null } });
     }
     return NextResponse.json({ user });
   } catch (err) {


### PR DESCRIPTION
## Summary
- handle missing override in `api/session`

## Testing
- `yarn lint`
- `npx tsc --noEmit`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688d5ef91aa48327b7fe9eeddc8238ff