### PR TITLE
Add null-safe user session handling and logging

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -15,15 +15,15 @@ export async function GET(req: NextRequest) {
   console.log('[api/session] incoming', { headerId, queryId, override });
   try {
     const user = await loadUserSession(override);
-    if (!user) {
+    if (!user || ('userId' in user && user.userId === null)) {
       if (override) {
         console.warn('[api/session] no user found for override', override);
       }
-      return NextResponse.json({ user: { id: null, user_role: null } });
+      return NextResponse.json({ user: null, isAuthenticated: false });
     }
-    return NextResponse.json({ user });
+    return NextResponse.json({ user, isAuthenticated: true });
   } catch (err) {
     console.error('[api/session] failed to load session', err);
-    return NextResponse.json({ user: null });
+    return NextResponse.json({ user: null, isAuthenticated: false });
   }
 }


### PR DESCRIPTION
## Summary
- log user lookup results and warn when no user is found
- return safe fallback session when user lookup fails
- ensure /api/session reports unauthenticated state for missing users

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_688e68bb23088327b3b3829f13183953