### PR TITLE
feat: guard loadUserSession against missing users

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -15,12 +15,21 @@ export async function GET(req: NextRequest) {
   console.log('[api/session] incoming', { headerId, queryId, override });
   try {
     const user = await loadUserSession(override);
-    if (!user || ('userId' in user && user.userId === null)) {
+
+    if (
+      !user ||
+      Object.keys(user).length === 0 ||
+      ('userId' in user && (user.userId === null || user.userId === undefined))
+    ) {
       if (override) {
         console.warn('[api/session] no user found for override', override);
+      } else {
+        console.warn('[api/session] no user resolved - returning guest session');
       }
+
       return NextResponse.json({ user: null, isAuthenticated: false });
     }
+
     return NextResponse.json({ user, isAuthenticated: true });
   } catch (err) {
     console.error('[api/session] failed to load session', err);


### PR DESCRIPTION
## Summary
- ensure `loadUserSession` selects from `users` by UUID id and logs query results
- add guards for missing/empty users and return guest session
- make `/api/session` resilient to unresolved users with explicit fallback

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_688ff3c4e6a08327b4a90163c44a3e59