### PR TITLE
refactor: enhance talent project access

### DIFF
--- a/app/(auth)/sign-up/page.tsx
+++ b/app/(auth)/sign-up/page.tsx
@@ -2,9 +2,12 @@
 import { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { TalentSignUpForm } from '@/components/TalentSignUpForm';
+import { useSearchParams } from 'next/navigation';
 
 export default function TalentSignUpPage() {
   const [loading, setLoading] = useState(false);
+  const searchParams = useSearchParams();
+  const roleIntent = searchParams.get('as');
 
   return (
     <main className="min-h-screen flex items-center justify-center bg-white p-4">
@@ -26,7 +29,11 @@ export default function TalentSignUpPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <TalentSignUpForm loading={loading} setLoading={setLoading} />
+            <TalentSignUpForm
+              loading={loading}
+              setLoading={setLoading}
+              roleIntent={roleIntent}
+            />
           </CardContent>
         </Card>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -33,7 +33,10 @@ export default function Home() {
               <h2 className="text-xl font-semibold mb-4 text-[#2F2F2F]">I'm a Professional</h2>
               <div className="space-y-4">
                 <FindProjectsButton />
-                <Link href="/talent/sign-up">
+                <p className="text-sm text-[#2F2F2F]">
+                  Sign up as Adhok Talent to view all projects
+                </p>
+                <Link href="/sign-up?as=talent">
                   <Button
                     variant="outline"
                     className="w-full border-[#2E3A8C] text-[#2E3A8C] hover:bg-[#2E3A8C]/10"

--- a/components/FindProjectsButton.tsx
+++ b/components/FindProjectsButton.tsx
@@ -1,17 +1,34 @@
 'use client';
 
-import Link from 'next/link';
+import React from 'react';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/lib/client/useAuthContext';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 export default function FindProjectsButton() {
-  const { isAuthenticated, loading } = useAuth();
-  const href = !loading && isAuthenticated ? '/talent/projects' : '/sign-in';
+  const { isAuthenticated, loading, userRole } = useAuth();
+  const router = useRouter();
+
+  const handleClick = () => {
+    if (loading) return;
+    if (!isAuthenticated) {
+      router.push('/sign-up?as=talent');
+      return;
+    }
+    if (userRole === 'talent') {
+      router.push('/talent/projects');
+    } else {
+      toast('You must be a talent user to browse projects.');
+    }
+  };
+
   return (
-    <Link href={href}>
-      <Button className="w-full bg-[#00A499] hover:bg-[#00A499]/90 text-white">
-        Find Projects
-      </Button>
-    </Link>
+    <Button
+      onClick={handleClick}
+      className="w-full bg-[#00A499] hover:bg-[#00A499]/90 text-white"
+    >
+      Find Projects
+    </Button>
   );
 }

--- a/components/TalentSignUpForm.tsx
+++ b/components/TalentSignUpForm.tsx
@@ -1,15 +1,24 @@
 'use client';
 import { SignUp } from '@clerk/nextjs';
+import { useEffect } from 'react';
 
 interface TalentSignUpFormProps {
   loading: boolean;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
+  roleIntent?: string | null;
 }
 
-export function TalentSignUpForm({ loading, setLoading }: TalentSignUpFormProps) {
+export function TalentSignUpForm({ loading, setLoading, roleIntent }: TalentSignUpFormProps) {
   void loading;
   void setLoading;
-  return (
-        <SignUp signInUrl="/sign-in" redirectUrl="/talent/dashboard" />
-  );
+
+  useEffect(() => {
+    if (roleIntent && typeof window !== 'undefined') {
+      window.localStorage.setItem('signup_role_intent', roleIntent);
+    }
+  }, [roleIntent]);
+
+  const redirectUrl = roleIntent === 'talent' ? '/talent/dashboard' : undefined;
+
+  return <SignUp signInUrl="/sign-in" redirectUrl={redirectUrl} />;
 }

--- a/tests/findProjectsButton.test.tsx
+++ b/tests/findProjectsButton.test.tsx
@@ -1,0 +1,50 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FindProjectsButton from '../components/FindProjectsButton';
+
+let pushMock: ReturnType<typeof vi.fn>;
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+let toastMock: ReturnType<typeof vi.fn>;
+vi.mock('sonner', () => ({
+  toast: (...args: unknown[]) => toastMock(...args),
+}));
+
+const useAuthMock = vi.fn();
+vi.mock('@/lib/client/useAuthContext', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+describe('FindProjectsButton', () => {
+  beforeEach(() => {
+    pushMock = vi.fn();
+    toastMock = vi.fn();
+    useAuthMock.mockReset();
+  });
+
+  it('routes unauthenticated users to signup', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: false, loading: false, userRole: null });
+    const { getByRole } = render(<FindProjectsButton />);
+    fireEvent.click(getByRole('button'));
+    expect(pushMock).toHaveBeenCalledWith('/sign-up?as=talent');
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+
+  it('routes talent users to project list', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: true, loading: false, userRole: 'talent' });
+    const { getByRole } = render(<FindProjectsButton />);
+    fireEvent.click(getByRole('button'));
+    expect(pushMock).toHaveBeenCalledWith('/talent/projects');
+  });
+
+  it('blocks non-talent users', () => {
+    useAuthMock.mockReturnValue({ isAuthenticated: true, loading: false, userRole: 'client' });
+    const { getByRole } = render(<FindProjectsButton />);
+    fireEvent.click(getByRole('button'));
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith('You must be a talent user to browse projects.');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./', import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
## Summary
- improve Find Projects button to route unauthenticated users to talent signup, talents to project list, and warn other roles
- support role intent in /sign-up and homepage CTA
- configure vitest aliases and add tests for navigation logic

## Testing
- `yarn verify`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688ff622ebf4832783ae801cf1fe8c14