### PR TITLE
Fix rawUser processing to avoid Object.entries crash

### DIFF
--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -116,24 +116,24 @@ export async function loadUserSession(
         `[loadUserSession] No user found for ID ${override} - returning fallback`
       );
       return fallback();
+    } else {
+      const user = Object.fromEntries(Object.entries(rawUser)) as typeof rawUser;
+      console.log('[loadUserSession] DB query result', user);
+
+      const hasProfile = await db
+        .select({ id: clientProfiles.id })
+        .from(clientProfiles)
+        .where(eq(clientProfiles.id, override))
+        .limit(1);
+
+      const session = { ...user, isClient: hasProfile.length > 0 };
+
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[loadUserSession] session', session);
+      }
+
+      return session;
     }
-
-    const user = Object.fromEntries(Object.entries(rawUser));
-    console.log('[loadUserSession] DB query result', user);
-
-    const hasProfile = await db
-      .select({ id: clientProfiles.id })
-      .from(clientProfiles)
-      .where(eq(clientProfiles.id, override))
-      .limit(1);
-
-    const session = { ...user, isClient: hasProfile.length > 0 };
-
-    if (process.env.NODE_ENV === 'development') {
-      console.log('[loadUserSession] session', session);
-    }
-
-    return session;
   } catch (err) {
     console.error('loadUserSession db error', err);
     return fallback();


### PR DESCRIPTION
## Summary
- prevent `Object.entries` from running on undefined user rows in `loadUserSession`
- assert raw user type after copying rows to retain field information

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_68911318326483278ad2e4bea3cbb6f7