### PR TITLE
refactor: stabilize hydration by moving client providers

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,6 @@
 // app/layout.tsx
 import '@/styles/globals.css';
-import { ClerkProvider } from '@clerk/nextjs';
-import { Toaster } from '@/components/ui/sonner';
-import { Header } from '@/components/Header';
-import { AuthProvider } from '@/lib/client/useAuthContext';
-import TestUserBadge from '@/components/dev/TestUserBadge';
-import NeonUserSwitcher from '@/components/dev/NeonUserSwitcher';
+import Providers from './providers';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,26 +10,11 @@ export const metadata = {
   icons: [{ rel: 'icon', url: '/favicon.svg' }],
 };
 
-const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API;
-
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const inner = (
-    <AuthProvider>
-      <Header />
-      {children}
-      <Toaster />
-      <NeonUserSwitcher />
-      <TestUserBadge />
-    </AuthProvider>
-  );
-
   return (
     <html lang="en">
-      <body suppressHydrationWarning={true}>
-        <ClerkProvider publishableKey={clerkKey} frontendApi={clerkApi}>
-          {inner}
-        </ClerkProvider>
+      <body>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import React from 'react';
+import { ClerkProvider } from '@clerk/nextjs';
+import { Header } from '@/components/Header';
+import { Toaster } from '@/components/ui/sonner';
+import { AuthProvider } from '@/lib/client/useAuthContext';
+import TestUserBadge from '@/components/dev/TestUserBadge';
+import NeonUserSwitcher from '@/components/dev/NeonUserSwitcher';
+
+const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API;
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <ClerkProvider publishableKey={clerkKey} frontendApi={clerkApi}>
+      <AuthProvider>
+        <Header />
+        {children}
+        <Toaster />
+        <NeonUserSwitcher />
+        <TestUserBadge />
+      </AuthProvider>
+    </ClerkProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move Clerk/Auth/Test badges to client-only Providers wrapper
- simplify root layout to static markup to avoid hydration mismatches

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_6891fe734554832790d399d8d9d9421f