### PR TITLE
Add load session marker and guard Object.entries calls

### DIFF
--- a/components/AdminLineChart.tsx
+++ b/components/AdminLineChart.tsx
@@ -121,7 +121,7 @@ export default function AdminLineChart({ selectedMetrics }: AdminLineChartProps)
           if (!talentMonths[m]) talentMonths[m] = new Set();
           talentMonths[m].add(t.id);
         });
-        Object.entries(talentMonths).forEach(([m, ids]: [string, Set<string>]) => {
+        (Object.entries(talentMonths ?? {}) as [string, Set<string>][]).forEach(([m, ids]) => {
           if (months[m]) months[m].activeTalent = ids.size;
         });
 

--- a/components/ProjectTemplateGrid.tsx
+++ b/components/ProjectTemplateGrid.tsx
@@ -31,7 +31,7 @@ export default function ProjectTemplateGrid({ templates, onSelectTemplate }: Pro
   return (
     <ScrollArea className="h-[600px] pr-4">
       <div className="space-y-8">
-        {Object.entries(groupedTemplates).map(([category, categoryTemplates]) => (
+        {(Object.entries(groupedTemplates ?? {}) as [string, ProjectTemplate[]][]).map(([category, categoryTemplates]) => (
           <div key={category}>
             <h2 className="text-lg font-semibold mb-4">{category}</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -72,8 +72,8 @@ const ChartContainer = React.forwardRef<
 ChartContainer.displayName = 'Chart';
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
-  const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
+  const colorConfig = (Object.entries(config ?? {}) as [string, ChartConfig[string]][]).filter(
+    ([_, cfg]) => cfg.theme || cfg.color
   );
 
   if (!colorConfig.length) {

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -65,9 +65,7 @@ export async function resolveUserId(
 export async function loadUserSession(
   overrideOrReq?: string | Request | NextRequest
 ) {
-  if (process.env.NODE_ENV === 'development') {
-    console.log('[loadUserSession] patched version invoked');
-  }
+  console.warn('🎉 patched loadUserSession loaded');
 
   const fallback = () => {
     if (process.env.NODE_ENV === 'development') {

--- a/scripts/processBrief.js
+++ b/scripts/processBrief.js
@@ -49,7 +49,7 @@ async function extractKeyInfo(text) {
     expert: /\b(?:senior|expert|advanced|specialist)\b/i,
     mid: /\b(?:mid[\s-]level|intermediate|regular)\b/i
   };
-  for (const [level, pattern] of Object.entries(expertisePatterns)) {
+  for (const [level, pattern] of Object.entries(expertisePatterns ?? {})) {
     if (pattern.test(text)) {
       info.expertiseLevel = level;
       break;
@@ -63,7 +63,7 @@ async function extractKeyInfo(text) {
     content: /\b(?:content|blog|article|copywriting)\b/i
   };
   info.channels = {};
-  for (const [channel, pattern] of Object.entries(channels)) {
+  for (const [channel, pattern] of Object.entries(channels ?? {})) {
     info.channels[channel] = pattern.test(text);
   }
   return info;


### PR DESCRIPTION
## Summary
- add a startup warning to `loadUserSession` for easier verification
- guard remaining `Object.entries` uses with safe defaults to avoid null issues

## Testing
- `yarn lint`
- `tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_689225aeaab883278bdd55b6638bc132