### PR TITLE
feat: harden env loading

### DIFF
--- a/app/api/dev/list-users/route.ts
+++ b/app/api/dev/list-users/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs';
 import { NextResponse, type NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
+import { sql } from 'drizzle-orm';
 
 export async function GET(_req: NextRequest) {
   if (process.env.NODE_ENV === 'production') {
@@ -13,6 +14,15 @@ export async function GET(_req: NextRequest) {
       .select({ id: users.id, full_name: users.fullName, username: users.username })
       .from(users)
       .limit(100);
+
+    // Raw SQL sanity check for development
+    try {
+      const sample = await db.execute(sql`SELECT * FROM users LIMIT 5`);
+      console.log('[list-users] sample rows:', sample);
+    } catch (err) {
+      console.warn('[list-users] raw query failed', err);
+    }
+
     return NextResponse.json({ users: data });
   } catch (err) {
     console.error('list-users error', err);

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -10,22 +10,29 @@ import NeonUserSwitcher from '@/components/dev/NeonUserSwitcher';
 
 const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
+const hasClerk = Boolean(clerkKey && clerkApi);
 
-if (!clerkKey || !clerkApi) {
+if (!hasClerk) {
   console.warn('Missing Clerk environment variables, running in mock mode');
 }
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return (
+  const content = (
+    <AuthProvider>
+      <Header />
+      {children}
+      <Toaster />
+      <NeonUserSwitcher />
+      <TestUserBadge />
+    </AuthProvider>
+  );
+
+  return hasClerk ? (
     <ClerkProvider publishableKey={clerkKey} frontendApi={clerkApi}>
-      <AuthProvider>
-        <Header />
-        {children}
-        <Toaster />
-        <NeonUserSwitcher />
-        <TestUserBadge />
-      </AuthProvider>
+      {content}
     </ClerkProvider>
+  ) : (
+    content
   );
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -7,11 +7,24 @@ if (typeof window !== 'undefined') {
   throw new Error('db should only be used server-side');
 }
 
-if (typeof process.env.DATABASE_URL !== 'string') {
-  throw new Error('DATABASE_URL is not defined in server environment');
+// Support both DATABASE_URL and NEON_DATABASE_URL to make local and
+// serverless environments interchangeable. Prefer DATABASE_URL when it is
+// set so developers can override locally.
+const connectionString =
+  process.env.DATABASE_URL || process.env.NEON_DATABASE_URL;
+
+if (typeof connectionString !== 'string') {
+  throw new Error(
+    'DATABASE_URL or NEON_DATABASE_URL must be defined in server environment',
+  );
 }
 
-const connectionString = process.env.DATABASE_URL;
+// Log which connection string is active so developers can verify the
+// configuration during startup. The full string can contain credentials, so
+// only print the first part for safety.
+const activeKey = process.env.DATABASE_URL ? 'DATABASE_URL' : 'NEON_DATABASE_URL';
+const redacted = connectionString.replace(/:\S+@/, ':***@');
+console.log(`[db] using ${activeKey}: ${redacted}`);
 
 const sql = neon(connectionString);
 

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -102,8 +102,8 @@ export async function loadUserSession(
       return fallback();
     }
 
-    // Safely build user object
-    const user = { ...rawUser };
+    // Safely build user object and guard against missing metadata
+    const user = { ...(rawUser as any), metadata: (rawUser as any).metadata ?? {} };
     console.log('[loadUserSession] user record:', user);
 
     // Check client profile existence

--- a/scripts/postinstall-cleanup.cjs
+++ b/scripts/postinstall-cleanup.cjs
@@ -11,12 +11,18 @@ if (currentMajor < MIN_NODE_MAJOR) {
 }
 
 
+// These modules are installed as transitive dependencies by some packages
+// but are not needed in this project. Removing them keeps the production
+// bundle smaller and avoids accidentally bundling native drivers.
 const paths = [
-  'node_modules/drizzle-orm/mysql-core',
-  'node_modules/drizzle-orm/sqlite-core',
+  // Unused type packages or helpers
   'node_modules/@types/better-sqlite3',
+  'node_modules/@types/mysql',
+  'node_modules/@types/sqlite3',
   'node_modules/bun-types',
-  'node_modules/@netlify/plugin-nextjs'
+
+  // Netlify plugin automatically added by Next.js in some setups
+  'node_modules/@netlify/plugin-nextjs',
 ];
 
 for (const p of paths) {


### PR DESCRIPTION
## Summary
- clean unused type packages in postinstall script
- log and verify active database connection string
- support mock mode when Clerk env vars missing
- add raw SQL sanity check for dev list-users route
- guard loadUserSession metadata for safety

## Testing
- `yarn test`
- `yarn type-check`

------
https://chatgpt.com/codex/tasks/task_e_6893d25fece083279963e341cdd0ceeb