### PR TITLE
chore: improve env setup and canvas stub

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,5 @@
 DATABASE_URL=postgres://localhost/mydb
+CLERK_API_KEY=your-clerk-api-key
+CLERK_SECRET_KEY=your-clerk-secret-key
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=your-clerk-publishable-key
+NEXT_PUBLIC_CLERK_FRONTEND_API=your-clerk-frontend-api

--- a/lib/server/loadUserSession.ts
+++ b/lib/server/loadUserSession.ts
@@ -57,9 +57,6 @@ export async function resolveUserId(
 export async function loadUserSession(
   overrideOrReq?: string | Request | NextRequest
 ) {
-  // Debug marker to confirm this version is running
-  console.warn('🎉 patched loadUserSession loaded');
-
   const fallback = () => {
     console.warn('🔄 loadUserSession fallback');
     return { userId: null, user_role: null } as const;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,15 @@ const nextConfig = {
       },
     ];
   },
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      canvas: '@empty/canvas',
+      'pdfjs-dist/canvas': '@empty/canvas',
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -117,9 +117,7 @@
   "resolutions": {
     "react-day-picker": "^8.9.4",
     "react-dnd": "^16.0.1",
-    "react-dnd-html5-backend": "^16.0.1",
-    "canvas": "@empty/canvas@0.0.0",
-    "pdfjs-dist/canvas": "@empty/canvas@0.0.0"
+    "react-dnd-html5-backend": "^16.0.1"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
- add placeholder Clerk env vars for development
- stub native canvas modules via webpack aliases
- drop yarn resolutions for canvas to avoid warnings
- streamline `loadUserSession` logging

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_6893d801a6608327aa42b1b730a062be