### PR TITLE
feat: add mockable auth and bidding fixes

### DIFF
--- a/app/api/dev/list-users/route.ts
+++ b/app/api/dev/list-users/route.ts
@@ -3,7 +3,6 @@ export const runtime = 'nodejs';
 import { NextResponse, type NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
-import { sql } from 'drizzle-orm';
 
 export async function GET(_req: NextRequest) {
   if (process.env.NODE_ENV === 'production') {
@@ -15,12 +14,8 @@ export async function GET(_req: NextRequest) {
       .from(users)
       .limit(100);
 
-    // Raw SQL sanity check for development
-    try {
-      const sample = await db.execute(sql`SELECT * FROM users LIMIT 5`);
-      console.log('[list-users] sample rows:', sample);
-    } catch (err) {
-      console.warn('[list-users] raw query failed', err);
+    if (process.env.NEXT_PUBLIC_DEBUG_DB === '1') {
+      console.log('[list-users] preview', data.slice(0, 5));
     }
 
     return NextResponse.json({ users: data });

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -2,17 +2,38 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { projects } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
 
 export async function GET(_req: NextRequest) {
   try {
-    const rows = await db.select().from(projects).limit(100);
-    console.log('[GET /api/projects] fetched', rows.length, 'projects from Neon');
-    if (rows.length === 0) {
-      console.warn('[GET /api/projects] no projects found');
+    const rows = await db
+      .select({
+        id: projects.id,
+        title: projects.title,
+        description: projects.description,
+        deadline: projects.deadline,
+        status: projects.status,
+        minimumBadge: projects.minimumBadge,
+        projectBudget: projects.projectBudget,
+        metadata: projects.metadata,
+      })
+      .from(projects)
+      .where(eq(projects.status, 'open'))
+      .limit(100);
+
+    const projectsData = rows.map((row: any) => ({
+      ...row,
+      metadata: { marketing: (row.metadata as any)?.marketing ?? {} },
+    }));
+
+    if (process.env.NEXT_PUBLIC_DEBUG_DB === '1') {
+      console.log('[GET /api/projects] fetched', projectsData.length, 'open projects');
     }
-    return NextResponse.json({ projects: rows });
+    return NextResponse.json({ projects: projectsData });
   } catch (error) {
-    console.error('[GET /api/projects] database error', error);
+    if (process.env.NEXT_PUBLIC_DEBUG_DB === '1') {
+      console.error('[GET /api/projects] database error', error);
+    }
     return NextResponse.json({ error: 'Failed to load projects' }, { status: 500 });
   }
 }

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,14 +1,40 @@
 export const runtime = 'nodejs';
 
 import { NextResponse } from 'next/server';
-import { loadUserSession } from '@/lib/loadUserSession';
+import { headers } from 'next/headers';
+import { db } from '@/lib/db';
+import { users } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
 
 export async function GET() {
+  const hdrs = await headers();
+  const overrideId = hdrs.get('x-override-user-id')?.trim();
+  if (!overrideId) {
+    return NextResponse.json({ session: null });
+  }
   try {
-    const user = await loadUserSession();
-    return NextResponse.json({ user, isAuthenticated: !!user });
+    const rows = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, overrideId))
+      .limit(1);
+    const row = rows[0];
+    if (!row) {
+      return NextResponse.json({ session: null });
+    }
+    return NextResponse.json({
+      session: {
+        userId: row.id,
+        userRole: row.userRole,
+        username: row.username,
+        fullName: row.fullName,
+        email: row.email,
+      },
+    });
   } catch (err) {
-    console.error('[api/session] failed to load session', err);
-    return NextResponse.json({ user: null, isAuthenticated: false });
+    if (process.env.NEXT_PUBLIC_DEBUG_AUTH === '1') {
+      console.error('[api/session] failed to load session', err);
+    }
+    return NextResponse.json({ session: null });
   }
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -11,9 +11,11 @@ import NeonUserSwitcher from '@/components/dev/NeonUserSwitcher';
 const clerkKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || '';
 const clerkApi = process.env.NEXT_PUBLIC_CLERK_FRONTEND_API || '';
 const hasClerk = Boolean(clerkKey && clerkApi);
+const useMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
+const shouldUseClerk = hasClerk && !useMock;
 
-if (!hasClerk) {
-  console.warn('Missing Clerk environment variables, running in mock mode');
+if (process.env.NEXT_PUBLIC_DEBUG_AUTH === '1') {
+  console.log('[providers] hasClerk:', hasClerk, 'useMock:', useMock);
 }
 
 export default function Providers({ children }: { children: React.ReactNode }) {
@@ -27,7 +29,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     </AuthProvider>
   );
 
-  return hasClerk ? (
+  return shouldUseClerk ? (
     <ClerkProvider publishableKey={clerkKey} frontendApi={clerkApi}>
       {content}
     </ClerkProvider>

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,11 @@ export function middleware(req: NextRequest) {
 
   const effective = (qsOverride ?? cookieOverride)?.trim() || undefined;
 
+  const debug = process.env.NEXT_PUBLIC_DEBUG_AUTH === '1';
+  if (debug) {
+    console.log('[middleware] override', { qsOverride, cookieOverride, effective });
+  }
+
   const headers = new Headers(req.headers);
   if (effective) {
     headers.set('x-override-user-id', effective);


### PR DESCRIPTION
## Summary
- support override header in middleware and new session endpoint
- mock-friendly auth provider and header
- refine projects API and bidding logic

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_689a6dbd9350832781a27fa2db357659