### PR TITLE
fix: resolve type errors and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ yarn install
 yarn setup-mock-data
 ```
 
+#### Seeding tiers
+
+Control how much demo content is loaded by setting the `TIER` environment variable:
+
+```bash
+# Minimal authentication records only
+TIER=basic yarn setup-mock-data
+
+# Auth records plus example projects and bids
+TIER=full yarn setup-mock-data
+```
+
 5. Start the development server:
 
 ```bash
@@ -39,6 +51,16 @@ Before pushing changes, run the verification suite:
 
 ```bash
 yarn verify
+```
+
+### Triggering Stripe test events
+
+Install the [Stripe CLI](https://stripe.com/docs/stripe-cli) and forward events to your local webhook handler:
+
+```bash
+stripe listen --forward-to localhost:3000/api/webhooks/stripe
+# Simulate a successful payment
+stripe trigger payment_intent.succeeded
 ```
 
 ### Neon User Switcher
@@ -52,6 +74,13 @@ Preview deployments (e.g. StackBlitz) can still use a mock authentication flow
 by setting `NEXT_PUBLIC_USE_MOCK=true` in the environment. This bypasses Clerk
 and loads a test user via the `/api/test-user` route so you can interact with
 authentic data while the login flow itself is mocked.
+
+### Per-project unlock toggle
+
+Project workspaces are normally read-only until unlocked. For local development you can:
+
+- Unlock all projects by setting `NEXT_PUBLIC_UNLOCK_ALL_PROJECTS=true` in `.env`.
+- Unlock a single project by appending `?unlock=<projectId>` to the project URL.
 
 ### Favicon
 

--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   ctx: { params: { id?: string } }
 ) {
   try {
-    const hdrs = headers(); // ✅ request scope
+    const hdrs = await headers(); // ✅ request scope
     const url = new URL(req.url);
 
     // Preferred source is the dynamic segment, but support query/override too

--- a/lib/client/useAuthContext.tsx
+++ b/lib/client/useAuthContext.tsx
@@ -57,7 +57,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   });
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const search = searchParams.toString();
+  const search = searchParams?.toString() ?? '';
   const hasFetchedOnce = useRef(false);
 
   const fetchSession = useCallback(async () => {

--- a/tests/authProvider.test.tsx
+++ b/tests/authProvider.test.tsx
@@ -24,11 +24,11 @@ describe('AuthProvider', () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ user: { userId: 'u1', userRole: 'client', metadata: {} } }),
+        json: async () => ({ session: { userId: 'u1', userRole: 'client', username: 'user1', fullName: null } }),
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ user: { userId: 'u2', userRole: 'client', metadata: {} } }),
+        json: async () => ({ session: { userId: 'u2', userRole: 'client', username: 'user2', fullName: null } }),
       });
     // @ts-ignore
     global.fetch = fetchMock;
@@ -50,18 +50,18 @@ describe('AuthProvider', () => {
       expect(screen.getByTestId('uid').textContent).toBe('u2');
     });
     expect(refreshSpy).toHaveBeenCalled();
-    expect(fetchMock).toHaveBeenLastCalledWith('/api/session');
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/session', { cache: 'no-store' });
   });
 
   it('keeps previous user if refresh resolves with null', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ user: { userId: 'u1', userRole: 'client', metadata: {} } }),
+        json: async () => ({ session: { userId: 'u1', userRole: 'client', username: 'user1', fullName: null } }),
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ user: null }),
+        json: async () => ({ session: null }),
       });
     // @ts-ignore
     global.fetch = fetchMock;


### PR DESCRIPTION
## Summary
- await Next.js headers in client projects route to satisfy strict types
- handle missing search params and align auth tests with session schema
- document seeding tiers, Stripe test events, and per-project unlock toggle

## Testing
- `tsc --noEmit --pretty false && echo "type check passed"`
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_689d02b86bd08327afd543417cc9fda8