### PR TITLE
Add accept bid analytics events and tests

### DIFF
--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   ctx: { params: { id?: string } }
 ) {
   try {
-    const hdrs = headers(); // ✅ request scope
+    const hdrs = await headers(); // ✅ request scope
     const url = new URL(req.url);
 
     // Preferred source is the dynamic segment, but support query/override too

--- a/cypress/e2e/accept-bid.cy.ts
+++ b/cypress/e2e/accept-bid.cy.ts
@@ -1,0 +1,18 @@
+// @ts-nocheck
+/* eslint-disable */
+
+export {};
+
+describe('Accept Bid', () => {
+  it('gates acceptance behind upgrade upsell', () => {
+    // TODO: implement test for upsell gating
+  });
+
+  it('allows per-project unlock after upgrade', () => {
+    // TODO: implement test for per-project unlock
+  });
+
+  it('locks other bids after one is accepted', () => {
+    // TODO: implement test for locking other bids
+  });
+});

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,5 @@
+export const accept_bid_clicked = 'accept_bid_clicked';
+export const accept_bid_success = 'accept_bid_success';
+export const accept_bid_gated_modal_open = 'accept_bid_gated_modal_open';
+export const accept_bid_project_unlock = 'accept_bid_project_unlock';
+export const client_upgrade_accept_bid_tier = 'client_upgrade_accept_bid_tier';


### PR DESCRIPTION
## Summary
- add accept bid analytics event constants
- stub accept bid cypress tests
- fix headers usage in client API route for type-checking

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_689d02b7125083279ff406843b2f756a