### PR TITLE
feat: add bid acceptance notification

### DIFF
--- a/lib/server/bids.ts
+++ b/lib/server/bids.ts
@@ -1,0 +1,37 @@
+import { db } from '@/lib/db';
+import { projectBids, projects } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import { notifyBidAccepted } from './notifications';
+
+interface AcceptBidParams {
+  projectId: string;
+  bidId: string;
+  talentId: string;
+  clientId: string;
+}
+
+/**
+ * Accept a bid for a project and notify the winning talent.
+ */
+export async function acceptBid({
+  projectId,
+  bidId,
+  talentId,
+  clientId,
+}: AcceptBidParams) {
+  return db.transaction(async tx => {
+    await tx
+      .update(projectBids)
+      .set({ status: 'accepted', updatedAt: new Date() })
+      .where(eq(projectBids.id, bidId));
+
+    await tx
+      .update(projects)
+      .set({ status: 'in_progress', talentId, updatedAt: new Date() })
+      .where(eq(projects.id, projectId));
+
+    await notifyBidAccepted({ projectId, bidId, talentId, clientId });
+  });
+}
+
+export type { AcceptBidParams };

--- a/lib/server/notifications.ts
+++ b/lib/server/notifications.ts
@@ -1,0 +1,31 @@
+import { db } from '@/lib/db';
+import { notifications } from '@/lib/schema';
+
+interface BidAcceptedParams {
+  projectId: string;
+  bidId: string;
+  talentId: string;
+  clientId: string;
+}
+
+/**
+ * Persist a notification when a bid is accepted.
+ * This writes directly to the notifications table so it can be surfaced to
+ * the notified user or picked up by a mock queue in tests.
+ */
+export async function notifyBidAccepted({
+  projectId,
+  bidId,
+  talentId,
+  clientId,
+}: BidAcceptedParams) {
+  await db.insert(notifications).values({
+    userId: talentId,
+    title: 'Bid accepted',
+    message: `Your bid on project ${projectId} was accepted`,
+    type: 'bid_accepted',
+    metadata: { projectId, bidId, talentId, clientId },
+  });
+}
+
+export type { BidAcceptedParams };


### PR DESCRIPTION
## Summary
- add `notifyBidAccepted` helper to store a bid-accepted notification
- ensure `acceptBid` transaction stores notification after marking bid and project

## Testing
- `yarn test` *(fails: TypeError: Cannot read properties of null (reading 'toString'))*

------
https://chatgpt.com/codex/tasks/task_e_689d02b5b8f48327a5da07c16173ccd0