### PR TITLE
Add client feature flag utilities

### DIFF
--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   ctx: { params: { id?: string } }
 ) {
   try {
-    const hdrs = headers(); // ✅ request scope
+    const hdrs = await headers(); // ✅ request scope
     const url = new URL(req.url);
 
     // Preferred source is the dynamic segment, but support query/override too

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -1,0 +1,52 @@
+import { db } from '@/lib/db';
+import { sql } from 'drizzle-orm';
+
+interface TierRow {
+  features: any;
+  tier_expires_at: string | null;
+}
+
+interface ProjectRow {
+  accept_bid_enabled: boolean | null;
+  client_id: string | null;
+}
+
+export async function hasFeatureForClient(
+  clientId: string,
+  featureKey: string
+): Promise<boolean> {
+  const res = await db.execute(
+    sql`select ct.features, ct.tier_expires_at
+        from client_profiles cp
+        join client_tiers ct on cp.id = ct.client_id
+        where cp.id = ${clientId}
+        limit 1`
+  );
+  const row = (res.rows as TierRow[])[0];
+  if (!row) return false;
+  if (
+    row.tier_expires_at &&
+    new Date(row.tier_expires_at).getTime() < Date.now()
+  ) {
+    return false;
+  }
+  const features = row.features ?? {};
+  if (Array.isArray(features)) {
+    return features.includes(featureKey);
+  }
+  return Boolean(features[featureKey]);
+}
+
+export async function hasAcceptBidForProject(
+  projectId: string
+): Promise<boolean> {
+  const res = await db.execute(
+    sql`select accept_bid_enabled, client_id from projects where id = ${projectId} limit 1`
+  );
+  const row = (res.rows as ProjectRow[])[0];
+  if (!row) return false;
+  if (row.accept_bid_enabled) return true;
+  if (!row.client_id) return false;
+  return hasFeatureForClient(row.client_id, 'accept_bid');
+}
+

--- a/lib/server/clients.ts
+++ b/lib/server/clients.ts
@@ -1,0 +1,25 @@
+import { db } from '@/lib/db';
+import { sql } from 'drizzle-orm';
+
+interface ClientWithTierRow {
+  client: any;
+  tier: any;
+}
+
+export async function getClientWithTier(clientId: string) {
+  const res = await db.execute(
+    sql`select row_to_json(cp.*) as client, row_to_json(ct.*) as tier
+        from client_profiles cp
+        left join client_tiers ct on cp.id = ct.client_id
+        where cp.id = ${clientId}
+        limit 1`
+  );
+  return (res.rows as ClientWithTierRow[])[0] ?? null;
+}
+
+export async function enableProjectAcceptBid(projectId: string) {
+  await db.execute(
+    sql`update projects set accept_bid_enabled = true where id = ${projectId}`
+  );
+}
+


### PR DESCRIPTION
## Summary
- support feature flags for clients and project accept-bid
- expose server helpers for client tiers and project flag updates
- fix headers access in clients API route

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_689d02addeb4832794eba3978cb30ec6