### PR TITLE
feat: add stripe webhook handling

### DIFF
--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -19,7 +19,7 @@ export async function GET(
   ctx: { params: { id?: string } }
 ) {
   try {
-    const hdrs = headers(); // ✅ request scope
+    const hdrs = await headers(); // ✅ request scope
     const url = new URL(req.url);
 
     // Preferred source is the dynamic segment, but support query/override too

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import Stripe from 'stripe';
+import env from '@/env.mjs';
+import { db } from '@/lib/db';
+import { clientProfiles } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import { getTierByStripePriceId } from '@/lib/billing/stripePlans';
+
+const stripe = new Stripe(env.STRIPE_SECRET_KEY, {
+  apiVersion: '2025-07-30.basil',
+});
+
+async function updateClientTier(options: {
+  clientId?: string | null;
+  priceId: string;
+  expiresAt?: number | null;
+}) {
+  if (!options.clientId) return;
+  const tier = await getTierByStripePriceId(options.priceId);
+  await db
+    .update(clientProfiles)
+    .set({
+      tierId: tier.id,
+      tierExpiresAt: options.expiresAt
+        ? new Date(options.expiresAt * 1000)
+        : null,
+    })
+    .where(eq(clientProfiles.id, options.clientId));
+}
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const sig = req.headers.get('stripe-signature');
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      payload,
+      sig || '',
+      env.STRIPE_WEBHOOK_SECRET,
+    );
+  } catch (err) {
+    console.error('Stripe webhook verification failed', err);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated': {
+        const subscription = event.data.object as Stripe.Subscription;
+        const priceId = subscription.items.data[0].price.id;
+        await updateClientTier({
+          clientId: subscription.metadata?.clientId,
+          priceId,
+          expiresAt: (subscription as any).current_period_end,
+        });
+        break;
+      }
+      case 'checkout.session.completed': {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (
+          session.mode === 'subscription' &&
+          typeof session.subscription === 'string'
+        ) {
+          const sub: any = await stripe.subscriptions.retrieve(
+            session.subscription,
+          );
+          await updateClientTier({
+            clientId: sub.metadata?.clientId,
+            priceId: sub.items.data[0].price.id,
+            expiresAt: sub.current_period_end,
+          });
+        } else if (session.metadata?.priceId) {
+          await updateClientTier({
+            clientId: session.metadata.clientId,
+            priceId: session.metadata.priceId,
+          });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+    return NextResponse.json({ received: true });
+  } catch (err) {
+    console.error('Error processing Stripe webhook', err);
+    return NextResponse.json({ error: 'Webhook handler error' }, { status: 500 });
+  }
+}

--- a/env.mjs
+++ b/env.mjs
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  STRIPE_SECRET_KEY: z.string(),
+  STRIPE_WEBHOOK_SECRET: z.string(),
+  STRIPE_PRICE_ACCEPT_BID: z.string(),
+  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: z.string(),
+});
+
+export const env = envSchema.parse(process.env);
+export default env;

--- a/lib/billing/stripePlans.ts
+++ b/lib/billing/stripePlans.ts
@@ -1,0 +1,29 @@
+import { db } from '@/lib/db';
+import { clientTiers, type ClientTier } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import env from '@/env.mjs';
+
+// Map Stripe price IDs to client_tiers IDs
+const PRICE_TO_TIER: Record<string, number> = {
+  [env.STRIPE_PRICE_ACCEPT_BID]: 1,
+};
+
+export async function getTierByStripePriceId(
+  priceId: string,
+): Promise<ClientTier> {
+  const tierId = PRICE_TO_TIER[priceId];
+  if (!tierId) {
+    throw new Error(`Unknown Stripe price ID: ${priceId}`);
+  }
+
+  const [tier] = await db
+    .select()
+    .from(clientTiers)
+    .where(eq(clientTiers.id, tierId));
+
+  if (!tier) {
+    throw new Error(`Tier not found for ID: ${tierId}`);
+  }
+
+  return tier;
+}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -182,10 +182,17 @@ export const waitlist = pgTable('waitlist', {
   signedUpAt: timestamp('signed_up_at').defaultNow()
 });
 
+export const clientTiers = pgTable('client_tiers', {
+  id: serial('id').primaryKey(),
+  name: text('name').notNull(),
+});
+export type ClientTier = typeof clientTiers.$inferSelect;
 
 export const clientProfiles = pgTable('client_profiles', {
   id: uuid('id').primaryKey(),
   email: text('email'),
   companyName: text('company_name'),
+  tierId: integer('tier_id').references(() => clientTiers.id),
+  tierExpiresAt: timestamp('tier_expires_at'),
 });
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "react-resizable-panels": "^2.0.11",
     "recharts": "^2.12.0",
     "sonner": "^1.4.0",
+    "stripe": "^18.4.0",
     "svix": "^1.20.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3674,6 +3674,7 @@ __metadata:
     react-resizable-panels: "npm:^2.0.11"
     recharts: "npm:^2.12.0"
     sonner: "npm:^1.4.0"
+    stripe: "npm:^18.4.0"
     svix: "npm:^1.20.0"
     tailwind-merge: "npm:^2.2.1"
     tailwindcss: "npm:^3.4.1"
@@ -8262,6 +8263,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.11.0":
+  version: 6.14.0
+  resolution: "qs@npm:6.14.0"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/8ea5d91bf34f440598ee389d4a7d95820e3b837d3fd9f433871f7924801becaa0cd3b3b4628d49a7784d06a8aea9bc4554d2b6d8d584e2d221dc06238a42909c
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -9355,6 +9365,20 @@ __metadata:
   dependencies:
     js-tokens: "npm:^9.0.1"
   checksum: 10c0/66a7353f5ba1ae6a4fb2805b4aba228171847200640083117c41512692e6b2c020e18580402984f55c0ae69c30f857f9a55abd672863e4ca8fdb463fdf93ba19
+  languageName: node
+  linkType: hard
+
+"stripe@npm:^18.4.0":
+  version: 18.4.0
+  resolution: "stripe@npm:18.4.0"
+  dependencies:
+    qs: "npm:^6.11.0"
+  peerDependencies:
+    "@types/node": ">=12.x.x"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10c0/abfae24fdc8a4cd96eb494f7582418c49e4db6e8dde21a9db6af8ee0ec02565f89fcf7c41902e0a555d4a733b5162702358114b3b5475343026965cb9b9f8529
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add Stripe webhook route to sync subscription tiers
- map Stripe price IDs to client tiers
- validate Stripe env vars and expose helper

## Testing
- `yarn lint`
- `yarn type-check`
- `yarn test` *(fails: Cannot read properties of null (reading 'toString'))*

------
https://chatgpt.com/codex/tasks/task_e_689d02ad01d483279b66a2ad3887c43c