### PR TITLE
Add client tier schema with feature flags

### DIFF
--- a/db/migrations/202501010000_add_client_tiers.sql
+++ b/db/migrations/202501010000_add_client_tiers.sql
@@ -1,0 +1,35 @@
+-- Create client_tiers table
+CREATE TABLE IF NOT EXISTS client_tiers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    description TEXT,
+    monthly_price INTEGER NOT NULL,
+    features TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Unique index on name
+CREATE UNIQUE INDEX IF NOT EXISTS idx_client_tiers_name ON client_tiers (name);
+
+-- Seed initial tiers
+INSERT INTO client_tiers (name, description, monthly_price, features)
+VALUES
+    ('Free', 'Default free tier', 0, '{}'),
+    ('Accept Bid Tier', 'Allows accepting bids', 0, ARRAY['accept_bid'])
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description,
+    monthly_price = EXCLUDED.monthly_price,
+    features = EXCLUDED.features;
+
+-- Alter client_profiles to include tier info
+ALTER TABLE client_profiles
+    ADD COLUMN IF NOT EXISTS tier_id UUID REFERENCES client_tiers(id),
+    ADD COLUMN IF NOT EXISTS tier_expires_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_clients_tier_id ON client_profiles (tier_id);
+
+-- Alter projects with accept_bid_enabled flag
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS accept_bid_enabled BOOLEAN DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_projects_accept_bid_enabled ON projects (accept_bid_enabled);

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,7 @@
-import { pgTable, text, uuid, timestamp } from 'drizzle-orm/pg-core';
+import { pgTable, text, uuid, timestamp, boolean, integer, jsonb } from 'drizzle-orm/pg-core';
+
+export const FEATURE_FLAGS = ['accept_bid'] as const;
+export type FeatureFlag = typeof FEATURE_FLAGS[number];
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey(),
@@ -10,3 +13,57 @@ export const users = pgTable('users', {
   created_at: timestamp('created_at'),
   updated_at: timestamp('updated_at')
 });
+
+export const companies = pgTable('companies', {
+  id: uuid('id').primaryKey(),
+  name: text('name').notNull(),
+  website: text('website'),
+  industry: text('industry'),
+  created_at: timestamp('created_at'),
+  updated_at: timestamp('updated_at')
+});
+
+export const client_tiers = pgTable('client_tiers', {
+  id: uuid('id').primaryKey(),
+  name: text('name').notNull().unique(),
+  description: text('description'),
+  monthly_price: integer('monthly_price').notNull(),
+  features: text('features').array().$type<FeatureFlag[]>(),
+  created_at: timestamp('created_at').defaultNow()
+});
+
+export const client_profiles = pgTable('client_profiles', {
+  id: uuid('id').primaryKey(),
+  email: text('email'),
+  company_name: text('company_name'),
+  tier_id: uuid('tier_id').references(() => client_tiers.id),
+  tier_expires_at: timestamp('tier_expires_at')
+});
+
+export const projects = pgTable('projects', {
+  id: uuid('id').primaryKey(),
+  title: text('title').notNull(),
+  description: text('description').notNull(),
+  status: text('status').notNull().default('draft'),
+  category: text('category'),
+  deadline: timestamp('deadline'),
+  project_budget: integer('project_budget'),
+  estimated_hours: integer('estimated_hours'),
+  hourly_rate: integer('hourly_rate'),
+  minimum_badge: text('minimum_badge'),
+  flagged: boolean('flagged').default(false),
+  accept_bid_enabled: boolean('accept_bid_enabled').default(false),
+  client_id: uuid('client_id').references(() => users.id),
+  talent_id: uuid('talent_id').references(() => users.id),
+  created_by: uuid('created_by').references(() => users.id),
+  requesting_user: uuid('requesting_user').references(() => users.id),
+  requesting_business: uuid('requesting_business').references(() => companies.id),
+  matched_talent: text('matched_talent'),
+  metadata: jsonb('metadata'),
+  created_at: timestamp('created_at'),
+  updated_at: timestamp('updated_at')
+});
+
+export type ClientTier = typeof client_tiers.$inferSelect;
+export type Client = typeof client_profiles.$inferSelect;
+export type Project = typeof projects.$inferSelect;

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,0 +1,43 @@
+import { eq } from 'drizzle-orm';
+import { db } from './index';
+import { clientTiers, clientProfiles, FeatureFlag } from './schema';
+
+async function seed() {
+  const tiers: { name: string; description: string; monthlyPrice: number; features: FeatureFlag[] }[] = [
+    { name: 'Free', description: 'Default free tier', monthlyPrice: 0, features: [] },
+    { name: 'Accept Bid Tier', description: 'Allows accepting bids', monthlyPrice: 0, features: ['accept_bid'] },
+  ];
+
+  for (const tier of tiers) {
+    await db
+      .insert(clientTiers)
+      .values(tier)
+      .onConflictDoUpdate({ target: clientTiers.name, set: tier });
+  }
+
+  // optional mock assignment: assign Accept Bid Tier to first client if exists
+  const [acceptBid] = await db
+    .select()
+    .from(clientTiers)
+    .where(eq(clientTiers.name, 'Accept Bid Tier'));
+
+  if (acceptBid) {
+    const [client] = await db.select().from(clientProfiles).limit(1);
+    if (client) {
+      await db
+        .update(clientProfiles)
+        .set({ tierId: acceptBid.id })
+        .where(eq(clientProfiles.id, client.id));
+    }
+  }
+}
+
+seed()
+  .then(() => {
+    console.log('Seed complete');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,4 +1,7 @@
-import { pgTable, serial, text, timestamp, uuid, boolean, jsonb, integer } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, uuid, boolean, jsonb, integer } from 'drizzle-orm/pg-core';
+
+export const FEATURE_FLAGS = ['accept_bid'] as const;
+export type FeatureFlag = typeof FEATURE_FLAGS[number];
 
 // Users table
 export const users = pgTable('users', {
@@ -22,6 +25,17 @@ export const companies = pgTable('companies', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow()
 });
+
+export const clientTiers = pgTable('client_tiers', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull().unique(),
+  description: text('description'),
+  monthlyPrice: integer('monthly_price').notNull(),
+  features: text('features').array().$type<FeatureFlag[]>(),
+  createdAt: timestamp('created_at').defaultNow()
+});
+
+export type ClientTier = typeof clientTiers.$inferSelect;
 
 // Talent profiles table
 export const talentProfiles = pgTable('talent_profiles', {
@@ -63,6 +77,7 @@ export const projects = pgTable('projects', {
   hourlyRate: integer('hourly_rate'),
   minimumBadge: text('minimum_badge'),
   flagged: boolean('flagged').default(false),
+  acceptBidEnabled: boolean('accept_bid_enabled').default(false),
   clientId: uuid('client_id').references(() => users.id),
   talentId: uuid('talent_id').references(() => users.id),
   createdBy: uuid('created_by').references(() => users.id),
@@ -73,6 +88,8 @@ export const projects = pgTable('projects', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow()
 });
+
+export type Project = typeof projects.$inferSelect;
 
 // Project bids table
 export const projectBids = pgTable('project_bids', {
@@ -187,5 +204,9 @@ export const clientProfiles = pgTable('client_profiles', {
   id: uuid('id').primaryKey(),
   email: text('email'),
   companyName: text('company_name'),
+  tierId: uuid('tier_id').references(() => clientTiers.id),
+  tierExpiresAt: timestamp('tier_expires_at'),
 });
+
+export type Client = typeof clientProfiles.$inferSelect;
 


### PR DESCRIPTION
## Summary
- add `client_tiers` table and feature flag union
- link clients and projects to new tier and accept bid flag
- seed default tiers and provide migration

## Testing
- `yarn test` *(fails: Cannot read properties of null (reading 'toString'))*


------
https://chatgpt.com/codex/tasks/task_e_689d02ac5ab0832781ab02ddbae6b675