### PR TITLE
feat: notify bid acceptance

### DIFF
--- a/lib/server/notifications.ts
+++ b/lib/server/notifications.ts
@@ -1,0 +1,32 @@
+import { db } from '@/lib/db';
+import { notifications } from '@/lib/schema';
+
+interface BidAcceptedArgs {
+  projectId: string;
+  bidId: string;
+  talentId: string;
+  clientId: string;
+}
+
+export async function notifyBidAccepted(
+  { projectId, bidId, talentId, clientId }: BidAcceptedArgs,
+  dbOrTx: typeof db = db,
+): Promise<void> {
+  await dbOrTx.insert(notifications).values([
+    {
+      userId: clientId,
+      title: 'Bid accepted',
+      message: `You accepted a bid for project ${projectId}`,
+      type: 'bid.accepted',
+      metadata: { projectId, bidId },
+    },
+    {
+      userId: talentId,
+      title: 'Bid accepted',
+      message: `Your bid for project ${projectId} was accepted`,
+      type: 'bid.accepted',
+      metadata: { projectId, bidId },
+    },
+  ]);
+}
+


### PR DESCRIPTION
## Summary
- add notifyBidAccepted helper to centralize bid acceptance notifications
- hook notifyBidAccepted into acceptBid transaction

## Testing
- `yarn lint lib/server/notifications.ts lib/server/bids.ts`
- `yarn test` *(fails: Cannot read properties of null (reading 'toString'))*

------
https://chatgpt.com/codex/tasks/task_e_689d0bdbcd848327ad32b0ce27ae389d