### PR TITLE
Add client tier feature types and auth guards

### DIFF
--- a/lib/auth/guards.ts
+++ b/lib/auth/guards.ts
@@ -1,0 +1,30 @@
+import { db } from '@/lib/db';
+import { projects } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import { hasFeatureForClient } from '@/lib/server/bids';
+import type { ClientTierFeatures } from '@/types/billing';
+
+export async function assertClientProjectOwner(
+  userId: string,
+  projectId: string,
+): Promise<void> {
+  const rows = await db
+    .select({ clientId: projects.clientId })
+    .from(projects)
+    .where(eq(projects.id, projectId))
+    .limit(1);
+
+  if (rows.length === 0 || rows[0].clientId !== userId) {
+    throw new Error('Forbidden');
+  }
+}
+
+export async function assertFeatureForClient(
+  clientId: string,
+  feature: keyof ClientTierFeatures,
+): Promise<void> {
+  const hasFeature = await hasFeatureForClient(clientId, feature);
+  if (!hasFeature) {
+    throw new Error('Forbidden');
+  }
+}

--- a/types/billing.ts
+++ b/types/billing.ts
@@ -1,0 +1,9 @@
+export interface ClientTierFeatures {
+  accept_bid: boolean;
+}
+
+export interface ClientTier {
+  features: ClientTierFeatures;
+}
+
+export type ClientTierFeatureName = keyof ClientTierFeatures;


### PR DESCRIPTION
## Summary
- define client tier features including accept bid support
- add authentication guards for project ownership and feature checks

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_689d0bd9d7e08327a8f5b24271be37fa