### PR TITLE
feat: add client tiers and accept bid support

### DIFF
--- a/db/migrations/202501010000_add_client_tiers.sql
+++ b/db/migrations/202501010000_add_client_tiers.sql
@@ -1,0 +1,26 @@
+-- Create client_tiers table
+CREATE TABLE IF NOT EXISTS client_tiers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    description TEXT,
+    monthly_price INTEGER NOT NULL,
+    features JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Add indexes for client_tiers
+CREATE UNIQUE INDEX IF NOT EXISTS idx_client_tiers_name ON client_tiers (name);
+
+-- Extend clients table with tier information
+ALTER TABLE clients
+    ADD COLUMN IF NOT EXISTS tier_id UUID REFERENCES client_tiers(id),
+    ADD COLUMN IF NOT EXISTS tier_expires_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_clients_tier_id ON clients (tier_id);
+
+-- Extend projects table with accept_bid_enabled
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS accept_bid_enabled BOOLEAN DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_projects_accept_bid_enabled ON projects (accept_bid_enabled);

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,12 @@
-import { pgTable, text, uuid, timestamp } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  text,
+  uuid,
+  timestamp,
+  boolean,
+  jsonb,
+  integer
+} from 'drizzle-orm/pg-core';
 
 export const users = pgTable('users', {
   id: uuid('id').primaryKey(),
@@ -10,3 +18,27 @@ export const users = pgTable('users', {
   created_at: timestamp('created_at'),
   updated_at: timestamp('updated_at')
 });
+
+export const client_tiers = pgTable('client_tiers', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  description: text('description'),
+  monthly_price: integer('monthly_price').notNull().default(0),
+  features: jsonb('features').notNull().default({}),
+  created_at: timestamp('created_at').defaultNow(),
+  updated_at: timestamp('updated_at').defaultNow()
+});
+
+export const clients = pgTable('clients', {
+  id: uuid('id').primaryKey().references(() => users.id),
+  tier_id: uuid('tier_id').references(() => client_tiers.id),
+  tier_expires_at: timestamp('tier_expires_at'),
+  created_at: timestamp('created_at').defaultNow(),
+  updated_at: timestamp('updated_at').defaultNow()
+});
+
+export const projects = pgTable('projects', {
+  id: uuid('id').primaryKey(),
+  accept_bid_enabled: boolean('accept_bid_enabled').default(false)
+});
+

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,0 +1,70 @@
+import { db } from '../lib/db';
+import { clientTiers, clients, users } from '../lib/schema';
+import { eq } from 'drizzle-orm';
+
+const tiers = [
+  {
+    name: 'Free',
+    description: 'Default tier with limited features',
+    monthlyPrice: 0,
+    features: { accept_bid: false },
+  },
+  {
+    name: 'Accept Bid Tier',
+    description: 'Allows clients to accept bids on projects',
+    monthlyPrice: 0,
+    features: { accept_bid: true },
+  },
+];
+
+async function seed() {
+  for (const tier of tiers) {
+    await db
+      .insert(clientTiers)
+      .values(tier)
+      .onConflictDoUpdate({
+        target: clientTiers.name,
+        set: {
+          description: tier.description,
+          monthlyPrice: tier.monthlyPrice,
+          features: tier.features,
+        },
+      });
+  }
+
+  const premium = await db
+    .select({ id: clientTiers.id })
+    .from(clientTiers)
+    .where(eq(clientTiers.name, 'Accept Bid Tier'))
+    .limit(1);
+
+  if (premium.length) {
+    const demoEmails = ['client1@example.com', 'client2@example.com'];
+    for (const email of demoEmails) {
+      const user = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, email))
+        .limit(1);
+      if (user.length) {
+        await db
+          .insert(clients)
+          .values({ id: user[0].id, tierId: premium[0].id })
+          .onConflictDoUpdate({
+            target: clients.id,
+            set: { tierId: premium[0].id },
+          });
+      }
+    }
+  }
+}
+
+seed()
+  .then(() => {
+    console.log('Seed complete');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,5 +1,7 @@
 import { pgTable, serial, text, timestamp, uuid, boolean, jsonb, integer } from 'drizzle-orm/pg-core';
 
+export type ClientTierFeature = 'accept_bid';
+
 // Users table
 export const users = pgTable('users', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -63,6 +65,7 @@ export const projects = pgTable('projects', {
   hourlyRate: integer('hourly_rate'),
   minimumBadge: text('minimum_badge'),
   flagged: boolean('flagged').default(false),
+  acceptBidEnabled: boolean('accept_bid_enabled').default(false),
   clientId: uuid('client_id').references(() => users.id),
   talentId: uuid('talent_id').references(() => users.id),
   createdBy: uuid('created_by').references(() => users.id),
@@ -73,6 +76,8 @@ export const projects = pgTable('projects', {
   createdAt: timestamp('created_at').defaultNow(),
   updatedAt: timestamp('updated_at').defaultNow()
 });
+
+export type Project = typeof projects.$inferSelect;
 
 // Project bids table
 export const projectBids = pgTable('project_bids', {
@@ -188,4 +193,27 @@ export const clientProfiles = pgTable('client_profiles', {
   email: text('email'),
   companyName: text('company_name'),
 });
+
+export const clientTiers = pgTable('client_tiers', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  description: text('description'),
+  monthlyPrice: integer('monthly_price').notNull().default(0),
+  features: jsonb('features')
+    .notNull()
+    .default({} as Record<ClientTierFeature, boolean>),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export const clients = pgTable('clients', {
+  id: uuid('id').primaryKey().references(() => users.id),
+  tierId: uuid('tier_id').references(() => clientTiers.id),
+  tierExpiresAt: timestamp('tier_expires_at'),
+  createdAt: timestamp('created_at').defaultNow(),
+  updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export type ClientTier = typeof clientTiers.$inferSelect;
+export type Client = typeof clients.$inferSelect;
 


### PR DESCRIPTION
## Summary
- add client tiers table and client tier relationships
- allow projects to enable accepting bids
- seed default tiers and update demo clients

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_689d0bd491388327b2c85e09801e989a