### PR TITLE
feat: add accept bid analytics events and tests

### DIFF
--- a/cypress/e2e/accept-bid.cy.ts
+++ b/cypress/e2e/accept-bid.cy.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+/* eslint-disable */
+
+describe('accept bid flow', () => {
+  it('shows upsell modal for non-subscribers', () => {
+    cy.login('client-free');
+    cy.visit('/projects/1/bids');
+    cy.get('[data-testid="bid-accept"]').first().click();
+    cy.get('[data-testid="upsell-modal"]').should('be.visible');
+  });
+
+  it('allows per-project unlock', () => {
+    cy.login('client-free');
+    cy.visit('/projects/1/bids');
+    cy.get('[data-testid="bid-accept"]').first().click();
+    cy.get('[data-testid="project-unlock"]').click();
+    cy.get('[data-testid="bid-accept"]').first().should('not.be.disabled');
+  });
+
+  it('disables other bids after acceptance', () => {
+    cy.login('client-pro');
+    cy.visit('/projects/1/bids');
+    cy.get('[data-testid="bid-accept"]').first().click();
+    cy.get('[data-testid="bid-accept"]').first().should('be.disabled');
+    cy.get('[data-testid="bid-accept"]').eq(1).should('be.disabled');
+  });
+});

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -1,0 +1,12 @@
+export const accept_bid_clicked = 'accept_bid_clicked';
+export const accept_bid_success = 'accept_bid_success';
+export const accept_bid_gated_modal_open = 'accept_bid_gated_modal_open';
+export const accept_bid_project_unlock = 'accept_bid_project_unlock';
+export const client_upgrade_accept_bid_tier = 'client_upgrade_accept_bid_tier';
+
+export type AcceptBidEvent =
+  | typeof accept_bid_clicked
+  | typeof accept_bid_success
+  | typeof accept_bid_gated_modal_open
+  | typeof accept_bid_project_unlock
+  | typeof client_upgrade_accept_bid_tier;


### PR DESCRIPTION
## Summary
- add analytics event constants for bid acceptance flow
- introduce Cypress E2E tests for upsell modal, project unlock, and bid disabling

## Testing
- `yarn verify`


------
https://chatgpt.com/codex/tasks/task_e_689d0bdd08bc8327b4aee45cbd0f8606