### PR TITLE
feat: redirect users to role-specific pages

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -30,26 +30,17 @@ export default function ClientDashboard() {
   const {
     userId,
     userRole,
-    username,
     authUser,
     loading: authLoading,
     isAuthenticated,
+    isClient,
   } = useAuth();
 
   useEffect(() => {
-    if (
-      !authLoading &&
-      (!authUser || (authUser.user_role !== 'client' && !authUser.isClient))
-    ) {
-      router.replace('/');
-    }
-  }, [authLoading, authUser, router]);
-
-  useEffect(() => {
-    if (!authLoading && isAuthenticated && userId) {
+    if (!authLoading && isAuthenticated && isClient && userId) {
       fetchProjects();
     }
-  }, [authLoading, isAuthenticated, userId]);
+  }, [authLoading, isAuthenticated, isClient, userId]);
 
   const fetchProjects = async () => {
     try {

--- a/app/client/layout.tsx
+++ b/app/client/layout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, type ReactNode } from 'react';
+import { useAuth } from '@/lib/client/useAuthContext';
+
+export default function ClientLayout({ children }: { children: ReactNode }) {
+  const { loading, userRole } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && userRole === 'talent') {
+      router.replace(pathname.replace(/^\/client/, '/talent'));
+    }
+  }, [loading, userRole, pathname, router]);
+
+  return <>{children}</>;
+}

--- a/app/client/projects/details/[project_id]/page.tsx
+++ b/app/client/projects/details/[project_id]/page.tsx
@@ -35,22 +35,15 @@ export default function ClientProjectDetail() {
   const [upsellOpen, setUpsellOpen] = useState(false);
   const {
     userId,
-    userRole,
     username,
     authUser,
     loading: authLoading,
   } = useAuth();
 
   useEffect(() => {
-    if (!authLoading && (!authUser || authUser.user_role !== 'client')) {
-      router.replace('/');
-    }
-  }, [authLoading, authUser, router]);
-
-  useEffect(() => {
     async function load() {
       try {
-        if (!project_id) return;
+        if (!project_id || !authUser || authUser.user_role !== 'client') return;
         const res = await fetch(`/api/db?table=projects&id=${project_id}`);
         const json = await res.json();
         const proj = json.data?.[0];
@@ -81,8 +74,8 @@ export default function ClientProjectDetail() {
         console.error('Error loading bids', err);
       }
     }
-    if (project_id) loadBids();
-  }, [project_id]);
+    if (project_id && authUser?.user_role === 'client') loadBids();
+  }, [project_id, authUser]);
 
   if (authLoading || !authUser) {
     return <p className="p-6 text-center text-gray-600">Loading...</p>;

--- a/app/client/upload/page.tsx
+++ b/app/client/upload/page.tsx
@@ -2,19 +2,9 @@
 
 import { useAuth } from '@/lib/client/useAuthContext';
 import { ProjectUploadFlow } from '@/components/ProjectUploadFlow';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
 export default function ClientUploadPage() {
-  const { loading, isClient, isAuthenticated } = useAuth();
-  const router = useRouter();
-
-  useEffect(() => {
-    // Only redirect if user is authenticated but not a client
-    if (!loading && isAuthenticated && !isClient) {
-      router.replace('/');
-    }
-  }, [loading, isClient, isAuthenticated, router]);
+  const { loading } = useAuth();
 
   if (loading) {
     return <p className="p-6 text-center text-gray-600">Loading...</p>;

--- a/app/talent/dashboard/page.tsx
+++ b/app/talent/dashboard/page.tsx
@@ -85,7 +85,7 @@ interface Project {
 }
 
 export default function TalentDashboard() {
-  const { userId } = useAuth();
+  const { userId, userRole } = useAuth();
   const router = useRouter();
 
   const [currentTab, setCurrentTab] = useState<'activeBids' | 'earnings' | 'portfolio' | 'won'>('activeBids');
@@ -100,7 +100,7 @@ export default function TalentDashboard() {
 
   useEffect(() => {
     async function load() {
-      if (!userId) return;
+      if (!userId || userRole !== 'talent') return;
       try {
         const res = await fetch('/api/db?table=projects');
         const json = await res.json();
@@ -140,7 +140,7 @@ export default function TalentDashboard() {
       }
     }
     load();
-  }, [userId]);
+  }, [userId, userRole]);
 
   const filteredProjects = projects.filter(p => p.status === 'complete');
   const wonProjects = projects.filter(

--- a/app/talent/layout.tsx
+++ b/app/talent/layout.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, type ReactNode } from 'react';
+import { useAuth } from '@/lib/client/useAuthContext';
+
+export default function TalentLayout({ children }: { children: ReactNode }) {
+  const { loading, userRole } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && userRole === 'client') {
+      router.replace(pathname.replace(/^\/talent/, '/client'));
+    }
+  }, [loading, userRole, pathname, router]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
- redirect talent visitors away from client routes and vice versa
- remove outdated client-side role checks and guard project data fetching
- restrict talent dashboard to load only for talent users

## Testing
- `yarn lint` *(fails: Prettier formatting failed)*
- `yarn type-check` *(fails: TS errors in bids API)*
- `yarn check-lockfile`
- `yarn check-eslint-versions`

------
https://chatgpt.com/codex/tasks/task_e_689f98a44178832796247211b7f98ffd