### PR TITLE
fix: load client projects on dashboard

### DIFF
--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -57,6 +57,8 @@ export async function GET(request: NextRequest) {
 
     let data;
     if (table === 'projects') {
+      // Use raw SQL to avoid projecting non-existent columns such as
+      // `accept_bid_enabled` which can break requests in older schemas.
       if (id) {
         const result = await db.execute(sql`select * from projects where id = ${id}`);
         data = result.rows;


### PR DESCRIPTION
## Summary
- resolve clientId from override query, header or param and log row count
- show empty and error states when fetching client projects
- document raw project query to avoid missing columns

## Testing
- `yarn verify`

------
https://chatgpt.com/codex/tasks/task_e_68a48a595adc8327a74c089375b1943d