### PR TITLE
Harden client dashboard project queries

### DIFF
--- a/app/api/clients/[id]/projects/route.ts
+++ b/app/api/clients/[id]/projects/route.ts
@@ -14,10 +14,24 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
     url.searchParams.get('override') ??
     req.headers.get('x-adhok-override') ??
     params.id;
+  if (!clientId) {
+    console.log('[clients.projects] no valid clientId');
+    return NextResponse.json(
+      { error: 'Missing client id' },
+      { status: 400 },
+    );
+  }
 
   try {
     const rows = await db
-      .select()
+      .select({
+        id: projects.id,
+        title: projects.title,
+        status: projects.status,
+        deadline: projects.deadline,
+        projectBudget: projects.projectBudget,
+        metadata: projects.metadata,
+      })
       .from(projects)
       .where(eq(projects.clientId, clientId));
     console.log('[clients.projects] clientId=%s rows=%d', clientId, rows.length);

--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -57,8 +57,7 @@ export async function GET(request: NextRequest) {
 
     let data;
     if (table === 'projects') {
-      // Use raw SQL to avoid projecting non-existent columns such as
-      // `accept_bid_enabled` which can break requests in older schemas.
+      // Use raw SQL to avoid projecting columns that may not exist in older schemas.
       if (id) {
         const result = await db.execute(sql`select * from projects where id = ${id}`);
         data = result.rows;

--- a/app/client/dashboard/ClientDashboardView.tsx
+++ b/app/client/dashboard/ClientDashboardView.tsx
@@ -49,9 +49,11 @@ export default function ClientDashboardView({ override }: ClientDashboardViewPro
       setLoading(true);
       setError(null);
       const id = override || userId;
-      const res = await fetch(`/api/clients/${id}/projects?override=${id}`, {
-        cache: 'no-store',
-      });
+      let url = `/api/clients/${id}/projects`;
+      if (override) {
+        url += `?override=${override}`;
+      }
+      const res = await fetch(url, { cache: 'no-store' });
       const json = await res.json();
       if (!res.ok) {
         console.error('Failed to fetch client projects:', json);

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,9 +1,15 @@
 import ClientDashboardView from './ClientDashboardView';
 
 interface PageProps {
-  searchParams?: { override?: string };
+  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 }
 
-export default function ClientDashboardPage({ searchParams }: PageProps) {
-  return <ClientDashboardView override={searchParams?.override} />;
+export default async function ClientDashboardPage({
+  searchParams,
+}: PageProps) {
+  const resolved = await searchParams;
+  const overrideParam = Array.isArray(resolved?.override)
+    ? resolved?.override[0]
+    : resolved?.override;
+  return <ClientDashboardView override={overrideParam} />;
 }

--- a/db/migrations/202501010000_add_client_tiers.sql
+++ b/db/migrations/202501010000_add_client_tiers.sql
@@ -8,8 +8,3 @@ ALTER TABLE clients
 
 CREATE INDEX IF NOT EXISTS idx_clients_tier_id ON clients (tier_id);
 
--- Extend projects table with accept_bid_enabled
-ALTER TABLE projects
-    ADD COLUMN IF NOT EXISTS accept_bid_enabled BOOLEAN DEFAULT FALSE;
-
-CREATE INDEX IF NOT EXISTS idx_projects_accept_bid_enabled ON projects (accept_bid_enabled);

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -3,7 +3,6 @@ import {
   text,
   uuid,
   timestamp,
-  boolean,
   jsonb,
   integer
 } from 'drizzle-orm/pg-core';
@@ -39,6 +38,5 @@ export const clients = pgTable('clients', {
 
 export const projects = pgTable('projects', {
   id: uuid('id').primaryKey(),
-  accept_bid_enabled: boolean('accept_bid_enabled').default(false)
 });
 

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -36,12 +36,10 @@ export async function hasFeatureForClient(
 
 export async function hasAcceptBidForProject(projectId: string): Promise<boolean> {
   const res = await db.execute(
-    sql`select accept_bid_enabled, client_id from projects where id = ${projectId} limit 1`,
+    sql`select client_id from projects where id = ${projectId} limit 1`,
   );
   const row = (res as any)?.rows?.[0];
-  if (!row) return false;
-  if (row.accept_bid_enabled) return true;
-  if (!row.client_id) return false;
+  if (!row || !row.client_id) return false;
   return hasFeatureForClient(row.client_id as string, 'accept-bid');
 }
 

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -65,7 +65,6 @@ export const projects = pgTable('projects', {
   hourlyRate: integer('hourly_rate'),
   minimumBadge: text('minimum_badge'),
   flagged: boolean('flagged').default(false),
-  acceptBidEnabled: boolean('accept_bid_enabled').default(false),
   clientId: uuid('client_id').references(() => users.id),
   talentId: uuid('talent_id').references(() => users.id),
   createdBy: uuid('created_by').references(() => users.id),

--- a/lib/server/bids.ts
+++ b/lib/server/bids.ts
@@ -22,16 +22,13 @@ export async function hasAcceptBidForProject(
   if (!bid) return false;
 
   const projectRows = await db
-    .select({
-      clientId: projects.clientId,
-      acceptBidEnabled: projects.acceptBidEnabled,
-    })
+    .select({ clientId: projects.clientId, metadata: projects.metadata })
     .from(projects)
     .where(eq(projects.id, bid.projectId))
     .limit(1);
   const project = projectRows[0] as any;
   if (!project || project.clientId !== input.clientId) return false;
-  if (project.acceptBidEnabled) return true;
+  if (project.metadata?.acceptBidEnabled) return true;
   return hasFeatureForClient(input.clientId, 'accept-bid');
 }
 

--- a/lib/server/clients.ts
+++ b/lib/server/clients.ts
@@ -13,10 +13,3 @@ export async function getClientWithTier(clientId: string) {
   );
   return (res as any)?.rows?.[0] ?? null;
 }
-
-export async function enableProjectAcceptBid(projectId: string): Promise<void> {
-  await db.execute(
-    sql`update projects set accept_bid_enabled = true where id = ${projectId}`,
-  );
-}
-


### PR DESCRIPTION
## Summary
- Make client dashboard page async and await `searchParams` before deriving override
- Resolve client project requests with safe clientId lookup and valid column set
- Strip deprecated `accept_bid_enabled` flag from schema and helpers

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e2cec9508327b26e240ea2fb6643