### PR TITLE
Fix server component search params and edge middleware

### DIFF
--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -1,18 +1,14 @@
 import ClientDashboardView from './ClientDashboardView';
 
-interface PageProps {
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
-}
-
 export default async function ClientDashboardPage({
   searchParams,
-}: PageProps) {
-  const params = (await searchParams) || {};
-  const override = Array.isArray(params.override)
-    ? params.override[0]
-    : params.override;
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const sp = await searchParams;
+  const override = typeof sp.override === 'string' ? sp.override : undefined;
 
-  let clientId = override as string | undefined;
+  let clientId = override;
   if (!clientId) {
     try {
       const sessionRes = await fetch('/api/session', { cache: 'no-store' });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,9 @@ export default async function Home({
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await searchParams;
+  const sp = await searchParams;
+  const override = typeof sp.override === "string" ? sp.override : undefined;
+  void override;
   return (
     <main className="min-h-screen bg-white">
       <div className="max-w-4xl mx-auto p-4 sm:p-6">

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,40 +1,12 @@
-import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 export function middleware(req: NextRequest) {
-  const url = req.nextUrl;
-  const qsOverride = url.searchParams.get('override');
-  const cookieOverride = req.cookies.get('adhok_override')?.value ?? undefined;
-
-  const effective = (qsOverride ?? cookieOverride)?.trim() || undefined;
-
-  const debug = process.env.NEXT_PUBLIC_DEBUG_AUTH === '1';
-  if (debug) {
-    console.log('[middleware] override', { qsOverride, cookieOverride, effective });
+  const override = new URL(req.url).searchParams.get('override');
+  const res = NextResponse.next();
+  if (override) {
+    res.headers.set('x-override-user-id', override);
   }
-
-  const headers = new Headers(req.headers);
-  if (effective) {
-    headers.set('x-override-user-id', effective);
-  } else {
-    headers.delete('x-override-user-id');
-  }
-
-  const res = NextResponse.next({ request: { headers } });
-
-  // Persist override as a client-readable cookie so a full reload keeps it
-  if (qsOverride !== null) {
-    if (effective) {
-      res.cookies.set('adhok_override', effective, {
-        path: '/',
-        httpOnly: false,
-        sameSite: 'lax',
-      });
-    } else {
-      res.cookies.delete('adhok_override');
-    }
-  }
-
   return res;
 }
 


### PR DESCRIPTION
## Summary
- handle `override` search param on home page and client dashboard server components
- clean edge middleware to only set `x-override-user-id` on response
- fetch client projects using params.id with optional override query

## Testing
- `yarn install`
- `yarn verify`
- `npx next dev`


------
https://chatgpt.com/codex/tasks/task_e_68a8a69728108327bd5e0ae17c28a87f