### PR TITLE
Guard request APIs and staticize root layout

### DIFF
--- a/app/api/clients/route.ts
+++ b/app/api/clients/route.ts
@@ -2,8 +2,7 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-import { NextResponse } from 'next/server';
-import { headers } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { sql } from 'drizzle-orm';
 // Optional (only used if real Clerk keys are present)
@@ -15,18 +14,17 @@ function inMockMode() {
 }
 
 export async function GET(
-  req: Request,
+  req: NextRequest,
   ctx: { params: { id?: string } }
 ) {
   try {
-      const hdrs = await headers(); // ✅ request scope
-    const url = new URL(req.url);
+    const url = req.nextUrl;
 
     // Preferred source is the dynamic segment, but support query/override too
     const pathId = ctx?.params?.id;
     const queryId = url.searchParams.get('id') ?? undefined;
     const override =
-      hdrs.get('x-override-user-id') ??
+      req.headers.get('x-override-user-id') ??
       url.searchParams.get('override') ??
       undefined;
 

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,14 +1,12 @@
 export const runtime = 'nodejs';
 
-import { NextResponse } from 'next/server';
-import { headers } from 'next/headers';
+import { NextResponse, type NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { users } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 
-export async function GET() {
-  const hdrs = await headers();
-  const overrideId = hdrs.get('x-override-user-id')?.trim();
+export async function GET(req: NextRequest) {
+  const overrideId = req.headers.get('x-override-user-id')?.trim();
   if (!overrideId) {
     return NextResponse.json({ session: null });
   }

--- a/app/client/dashboard/page.tsx
+++ b/app/client/dashboard/page.tsx
@@ -3,7 +3,7 @@ import ClientDashboardView from './ClientDashboardView';
 export default async function ClientDashboardPage({
   searchParams,
 }: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
+  searchParams: Promise<Record<string, string | string[]>>;
 }) {
   const sp = await searchParams;
   const override = typeof sp.override === 'string' ? sp.override : undefined;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,6 @@
 import '@/styles/globals.css';
 import Providers from './providers';
 
-export const dynamic = 'force-dynamic';
-
 export const metadata = {
   title: 'Adhok',
   description: 'Next.js + Clerk App',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import FindProjectsButton from "@/components/FindProjectsButton";
 export default async function Home({
   searchParams,
 }: {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
+  searchParams: Promise<Record<string, string | string[]>>;
 }) {
   const sp = await searchParams;
   const override = typeof sp.override === "string" ? sp.override : undefined;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "preinstall": "node scripts/check-banned-packages.cjs",
     "check-lockfile": "node scripts/check-package-manager.cjs",
     "check-eslint-versions": "node scripts/check-eslint-versions.cjs",
-    "verify": "yarn lint && yarn type-check && yarn check-lockfile && yarn check-eslint-versions",
+    "check-request-apis": "node scripts/check-request-apis.cjs",
+    "verify": "yarn lint && yarn type-check && yarn check-lockfile && yarn check-eslint-versions && yarn check-request-apis",
     "test": "vitest run"
   },
   "packageManager": "yarn@4.9.2",

--- a/scripts/check-request-apis.cjs
+++ b/scripts/check-request-apis.cjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function walk(dir) {
+  let results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(walk(full));
+    } else {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const appDir = path.join(process.cwd(), 'app');
+let failed = false;
+
+if (fs.existsSync(appDir)) {
+  const files = walk(appDir);
+  const layoutIssues = [];
+  const headerIssues = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf8');
+    if (/\/layout\.tsx?$/.test(file) && /['"]use client['"]/.test(content)) {
+      layoutIssues.push(file);
+    }
+    if (/from ['"]next\/headers['"]/.test(content)) {
+      headerIssues.push(file);
+    }
+  }
+
+  if (layoutIssues.length) {
+    console.error('layout.tsx files must not use "use client":');
+    layoutIssues.forEach(f => console.error(' - ' + f));
+    failed = true;
+  }
+
+  if (headerIssues.length) {
+    console.error('Files under app/ must not import next/headers:');
+    headerIssues.forEach(f => console.error(' - ' + f));
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- avoid `next/headers` in API routes by reading headers from `NextRequest`
- make root-level pages server components that await `searchParams`
- add `check-request-apis` script to block client layouts and rogue `next/headers` imports

## Testing
- `yarn verify`
- `yarn check-request-apis`


------
https://chatgpt.com/codex/tasks/task_e_68add67abd908327b29581d245335a7e