### PR TITLE
refactor: use request nextUrl and solidify bid tx

### DIFF
--- a/app/api/bids/[bidId]/accept/route.ts
+++ b/app/api/bids/[bidId]/accept/route.ts
@@ -14,9 +14,9 @@ type RouteContext = { params: Promise<{ bidId: string }> };
 export async function POST(req: NextRequest, ctx: RouteContext) {
   const { bidId } = await ctx.params;
 
-  const url = new URL(req.url);
   const override =
-    req.headers.get('x-override-user-id') || url.searchParams.get('override');
+    req.headers.get('x-override-user-id') ||
+    req.nextUrl.searchParams.get('override');
   const useMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';
   const clerkActive = !!process.env.CLERK_SECRET_KEY && !useMock;
 
@@ -43,7 +43,9 @@ export async function POST(req: NextRequest, ctx: RouteContext) {
   }
 
   try {
-    await db.transaction(async (tx: Tx) => acceptBid(tx, { bidId, clientId }));
+    await db.transaction(async (tx: unknown) => {
+      await acceptBid(tx as Tx, { bidId, clientId });
+    });
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('[POST /api/bids/[bidId]/accept] error', error);

--- a/app/api/db/route.ts
+++ b/app/api/db/route.ts
@@ -25,11 +25,11 @@ export async function GET(request: NextRequest) {
   // Support optional mock user override via header or query param
   const userId =
     request.headers.get('x-override-user-id') ||
-    new URL(request.url).searchParams.get('override') ||
+    request.nextUrl.searchParams.get('override') ||
     undefined;
 
   try {
-    const url = new URL(request.url);
+    const url = request.nextUrl;
     const table = url.searchParams.get('table');
     const id = url.searchParams.get('id');
 
@@ -124,7 +124,7 @@ export async function PUT(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    const url = new URL(request.url);
+    const url = request.nextUrl;
     const table = url.searchParams.get('table');
     const id = url.searchParams.get('id');
     

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -39,6 +39,9 @@ export async function GET(req: NextRequest) {
     if (process.env.NEXT_PUBLIC_DEBUG_AUTH === '1') {
       console.error('[api/session] failed to load session', err);
     }
-    return NextResponse.json({ session: null });
+    return NextResponse.json(
+      { error: 'Failed to load session' },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/talent/profile/route.ts
+++ b/app/api/talent/profile/route.ts
@@ -12,7 +12,7 @@ const bodySchema = z.object({
 });
 
 export async function GET(req: NextRequest) {
-  const url = new URL(req.url);
+  const url = req.nextUrl;
   const paramId = url.searchParams.get('id');
   const override =
     req.headers.get('x-override-user-id') || url.searchParams.get('override');
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const url = new URL(req.url);
+  const url = req.nextUrl;
   const override =
     req.headers.get('x-override-user-id') || url.searchParams.get('override');
   const useMock = process.env.NEXT_PUBLIC_USE_MOCK === 'true';

--- a/app/api/test-user/route.ts
+++ b/app/api/test-user/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { selectUserByRole, type TestRole } from '@/server/selectUserByRole';
 
 export async function GET(req: NextRequest) {
-  const role = (new URL(req.url).searchParams.get('role') as TestRole) || 'talent';
+  const role = (req.nextUrl.searchParams.get('role') as TestRole) || 'talent';
   const user = await selectUserByRole(role);
   return NextResponse.json({ user });
 }

--- a/lib/server/bids.ts
+++ b/lib/server/bids.ts
@@ -5,10 +5,12 @@ import { projectBids, projects } from '@/lib/schema';
 import { eq, and, ne } from 'drizzle-orm';
 import { notifyBidAccepted } from '@/lib/server/notifications';
 import { hasFeatureForClient } from '@/lib/featureFlags';
+import type * as schema from '@/lib/schema';
+import type { NeonTransaction } from 'drizzle-orm/neon-http/session';
 export { hasFeatureForClient };
 
 export type AcceptBidInput = { bidId: string; clientId: string };
-export type Tx = typeof db;
+export type Tx = NeonTransaction<typeof schema, typeof schema>;
 
 export async function hasAcceptBidForProject(
   input: AcceptBidInput,

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(req: NextRequest) {
-  const override = new URL(req.url).searchParams.get('override');
+  const override = req.nextUrl.searchParams.get('override');
   const res = NextResponse.next();
   if (override) {
     res.headers.set('x-override-user-id', override);


### PR DESCRIPTION
## Summary
- refine bid acceptance by using typed Neon transaction
- rely on `req.nextUrl` across middleware and API routes
- ensure session endpoint returns JSON errors

## Testing
- `yarn type-check`
- `yarn lint`
- `yarn check-request-apis`


------
https://chatgpt.com/codex/tasks/task_e_68ae1b60938c83278827da7ed4c9b406