### PR TITLE
fix: use React use for searchParams

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,14 @@ import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import Link from "next/link";
 import FindProjectsButton from "@/components/FindProjectsButton";
+import { use } from "react";
 
-export default async function Home({
+export default function Home({
   searchParams,
 }: {
-  searchParams: Promise<Record<string, string | string[]>>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const sp = await searchParams;
+  const sp = use(searchParams);
   const override = typeof sp.override === "string" ? sp.override : undefined;
   void override;
   return (

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- handle searchParams via React `use()` to avoid work unit storage error
- update Next.js env types reference

## Testing
- `yarn type-check`
- `yarn verify` *(fails: command hung during check-lockfile step)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1fefdbbc8327bcde6c883affffed